### PR TITLE
Error status log

### DIFF
--- a/CRISPResso2/CRISPRessoAggregateCORE.py
+++ b/CRISPResso2/CRISPRessoAggregateCORE.py
@@ -76,8 +76,7 @@ ___________________________________
         output_folder_name='CRISPRessoAggregate_on_%s' % args.name
         OUTPUT_DIRECTORY=os.path.abspath(output_folder_name)
 
-
-        _jp=lambda filename: os.path.join(OUTPUT_DIRECTORY, filename) #handy function to put a file in the output directory
+        _jp = lambda filename: os.path.join(OUTPUT_DIRECTORY, filename) #handy function to put a file in the output directory
 
         try:
              info('Creating Folder %s' % OUTPUT_DIRECTORY)
@@ -87,6 +86,7 @@ ___________________________________
 
         log_filename=_jp('CRISPRessoAggregate_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('status.txt')))
 
         with open(log_filename, 'w+') as outfile:
               outfile.write('[Command used]:\n%s\n\n[Execution log]:\n' % ' '.join(sys.argv))
@@ -845,7 +845,7 @@ ___________________________________
         wait(process_results)
         process_pool.shutdown()
 
-        info('Analysis Complete!')
+        info('Analysis Complete!', {'percent_complete': 100})
         print(CRISPRessoShared.get_crispresso_footer())
         sys.exit(0)
 

--- a/CRISPResso2/CRISPRessoAggregateCORE.py
+++ b/CRISPResso2/CRISPRessoAggregateCORE.py
@@ -86,7 +86,7 @@ ___________________________________
 
         log_filename=_jp('CRISPRessoAggregate_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPResso_status.txt')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPRessoAggregate_status.txt')))
 
         with open(log_filename, 'w+') as outfile:
               outfile.write('[Command used]:\n%s\n\n[Execution log]:\n' % ' '.join(sys.argv))

--- a/CRISPResso2/CRISPRessoAggregateCORE.py
+++ b/CRISPResso2/CRISPRessoAggregateCORE.py
@@ -201,7 +201,7 @@ ___________________________________
                         warn('Could not process WGS folder ' + folder)
                         not_imported_count += 1
 
-        info('Read ' + str(successfully_imported_count) + ' folders (' + str(not_imported_count) + ' not imported)')
+        info('Read ' + str(successfully_imported_count) + ' folders (' + str(not_imported_count) + ' not imported)', {'percent_complete': 10})
 
         save_png = True
         if args.suppress_report:
@@ -280,6 +280,8 @@ ___________________________________
             window_nuc_conv_plot_names = []
             nuc_conv_plot_names = []
 
+            percent_complete_start, percent_complete_end = 11, 90
+            percent_complete_step = (percent_complete_end - percent_complete_start) / len(all_amplicons)
             #report for amplicons that appear multiple times
             for amplicon_index, amplicon_seq in enumerate(all_amplicons):
                 amplicon_name = amplicon_names[amplicon_seq]
@@ -288,7 +290,8 @@ ___________________________________
                 if amplicon_counts[amplicon_seq] < 2:
                     continue
 
-                info('Reporting summary for amplicon: "' + amplicon_name + '"')
+                percent_complete = percent_complete_start + (amplicon_index * percent_complete_step)
+                info('Reporting summary for amplicon: "' + amplicon_name + '"', {'percent_complete': percent_complete})
 
                 consensus_sequence = ""
                 nucleotide_frequency_summary = []
@@ -687,6 +690,7 @@ ___________________________________
 
             quantification_summary=[]
             #summarize amplicon modifications
+            debug('Summarizing amplicon modifications...', {'percent_complete': 92})
             samples_quantification_summary_by_amplicon_filename = _jp('CRISPRessoAggregate_quantification_of_editing_frequency_by_amplicon.txt') #this file has separate lines for each amplicon in each run
             with open(samples_quantification_summary_by_amplicon_filename, 'w') as outfile:
                 wrote_header = False
@@ -758,7 +762,7 @@ ___________________________________
 
             if not args.suppress_plots:
                 plot_root = _jp("CRISPRessoAggregate_reads_summary")
-
+                debug('Plotting reads summary...', {'percent_complete': 94})
                 reads_total_input = {
                     'fig_filename_root': plot_root,
                     'df_summary_quantification': df_summary_quantification,
@@ -792,6 +796,7 @@ ___________________________________
                 crispresso2_info['results']['general_plots']['summary_plot_datas'][plot_name] = [('CRISPRessoAggregate summary', os.path.basename(samples_quantification_summary_filename)), ('CRISPRessoAggregate summary by amplicon', os.path.basename(samples_quantification_summary_by_amplicon_filename))]
 
             #summarize alignment
+            debug('Summarizing alignment...', {'percent_complete': 96})
             with open(_jp('CRISPRessoAggregate_mapping_statistics.txt'), 'w') as outfile:
                 wrote_header = False
                 for crispresso2_folder in crispresso2_folders:

--- a/CRISPResso2/CRISPRessoAggregateCORE.py
+++ b/CRISPResso2/CRISPRessoAggregateCORE.py
@@ -23,15 +23,11 @@ from CRISPResso2.CRISPRessoMultiProcessing import get_max_processes, run_plot
 
 
 import logging
-logging.basicConfig(
-                     format='%(levelname)-5s @ %(asctime)s:\n\t %(message)s \n',
-                     datefmt='%a, %d %b %Y %H:%M:%S',
-                     stream=sys.stderr,
-                     filemode="w"
-                     )
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(CRISPRessoShared.LogStreamHandler())
+
 error   = logger.critical
 warn    = logger.warning
 debug   = logger.debug

--- a/CRISPResso2/CRISPRessoAggregateCORE.py
+++ b/CRISPResso2/CRISPRessoAggregateCORE.py
@@ -86,7 +86,7 @@ ___________________________________
 
         log_filename=_jp('CRISPRessoAggregate_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('status.txt')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPResso_status.txt')))
 
         with open(log_filename, 'w+') as outfile:
               outfile.write('[Command used]:\n%s\n\n[Execution log]:\n' % ' '.join(sys.argv))

--- a/CRISPResso2/CRISPRessoAggregateCORE.py
+++ b/CRISPResso2/CRISPRessoAggregateCORE.py
@@ -69,6 +69,8 @@ ___________________________________
 
         args = parser.parse_args()
 
+        CRISPRessoShared.set_console_log_level(logger, args.verbosity, args.debug)
+
         output_folder_name='CRISPRessoAggregate_on_%s' % args.name
         OUTPUT_DIRECTORY=os.path.abspath(output_folder_name)
 

--- a/CRISPResso2/CRISPRessoBatchCORE.py
+++ b/CRISPResso2/CRISPRessoBatchCORE.py
@@ -280,7 +280,7 @@ def main():
         crispresso2_info['results']['batch_names_arr'] = batch_names_arr
         crispresso2_info['results']['batch_input_names'] = batch_input_names
 
-        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes_for_batch, 'batch', args.skip_failed)
+        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes_for_batch, 'batch', args.skip_failed, start_end_percent=[10, 90])
 
         run_datas = [] # crispresso2 info from each row
 
@@ -364,6 +364,8 @@ def main():
         crispresso2_info['results']['general_plots']['allele_modification_line_plot_labels'] = {}
         crispresso2_info['results']['general_plots']['allele_modification_line_plot_datas'] = {}
 
+        percent_complete_start, percent_complete_end = 90, 99
+        percent_complete_step = (percent_complete_end - percent_complete_start) / len(all_amplicons)
         # report for amplicons
         for amplicon_index, amplicon_seq in enumerate(all_amplicons):
             # only perform comparison if amplicon seen in more than one sample
@@ -371,7 +373,8 @@ def main():
                 continue
 
             amplicon_name = amplicon_names[amplicon_seq]
-            info('Reporting summary for amplicon: "' + amplicon_name + '"')
+            percent_complete = percent_complete_start + (amplicon_index * percent_complete_step)
+            info('Reporting summary for amplicon: "' + amplicon_name + '"', {'percent_complete': percent_complete})
 
             consensus_sequence = ""
             nucleotide_frequency_summary = []
@@ -577,6 +580,7 @@ def main():
                                 'sgRNA_intervals': sub_sgRNA_intervals,
                                 'quantification_window_idxs': include_idxs,
                             }
+                            debug('Plotting nucleotide percentage quilt for amplicon {0}, sgRNA {1}'.format(amplicon_name, sgRNA))
                             plot(
                                 CRISPRessoPlot.plot_nucleotide_quilt,
                                 nucleotide_quilt_input,
@@ -600,6 +604,7 @@ def main():
                                     'sgRNA_intervals': sub_sgRNA_intervals,
                                     'quantification_window_idxs': include_idxs,
                                 }
+                                debug('Plotting nucleotide conversion map for amplicon {0}, sgRNA {1}'.format(amplicon_name, sgRNA))
                                 plot(
                                     CRISPRessoPlot.plot_conversion_map,
                                     conversion_map_input,
@@ -625,6 +630,7 @@ def main():
                             'sgRNA_intervals': consensus_sgRNA_intervals,
                             'quantification_window_idxs': include_idxs,
                         }
+                        debug('Plotting nucleotide quilt for {0}'.format(amplicon_name))
                         plot(
                             CRISPRessoPlot.plot_nucleotide_quilt,
                             nucleotide_quilt_input,
@@ -647,6 +653,7 @@ def main():
                                 'sgRNA_intervals': consensus_sgRNA_intervals,
                                 'quantification_window_idxs': include_idxs,
                             }
+                            debug('Plotting nucleotide conversion map for {0}'.format(amplicon_name))
                             plot(
                                 CRISPRessoPlot.plot_conversion_map,
                                 conversion_map_input,
@@ -669,6 +676,7 @@ def main():
                             'fig_filename_root': this_nuc_pct_quilt_plot_name,
                             'save_also_png': save_png,
                         }
+                        debug('Plotting nucleotide quilt for {0}'.format(amplicon_name))
                         plot(
                             CRISPRessoPlot.plot_nucleotide_quilt,
                             nucleotide_quilt_input,
@@ -686,6 +694,7 @@ def main():
                                 'conversion_nuc_to': args.conversion_nuc_to,
                                 'save_also_png': save_png,
                             }
+                            debug('Plotting BE nucleotide conversion map for {0}'.format(amplicon_name))
                             plot(
                                 CRISPRessoPlot.plot_conversion_map,
                                 conversion_map_input,
@@ -728,6 +737,7 @@ def main():
                             'plot_path': plot_path,
                             'title': modification_type,
                         }
+                        debug('Plotting allele modification heatmap for {0}'.format(amplicon_name))
                         plot(
                             CRISPRessoPlot.plot_allele_modification_heatmap,
                             allele_modification_heatmap_input,
@@ -758,6 +768,7 @@ def main():
                             'plot_path': plot_path,
                             'title': modification_type,
                         }
+                        debug('Plotting allele modification line plot for {0}'.format(amplicon_name))
                         plot(
                             CRISPRessoPlot.plot_allele_modification_line,
                             allele_modification_line_input,

--- a/CRISPResso2/CRISPRessoBatchCORE.py
+++ b/CRISPResso2/CRISPRessoBatchCORE.py
@@ -113,7 +113,7 @@ def main():
 
         log_filename = _jp('CRISPRessoBatch_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
-        status_handler = CRISPRessoShared.StatusHandler(_jp('status.txt'))
+        status_handler = CRISPRessoShared.StatusHandler(_jp('CRISPResso_status.txt'))
         logger.addHandler(status_handler)
 
         with open(log_filename, 'w+') as outfile:

--- a/CRISPResso2/CRISPRessoBatchCORE.py
+++ b/CRISPResso2/CRISPRessoBatchCORE.py
@@ -113,7 +113,7 @@ def main():
 
         log_filename = _jp('CRISPRessoBatch_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
-        status_handler = CRISPRessoShared.StatusHandler(_jp('CRISPResso_status.txt'))
+        status_handler = CRISPRessoShared.StatusHandler(_jp('CRISPRessoBatch_status.txt'))
         logger.addHandler(status_handler)
 
         with open(log_filename, 'w+') as outfile:

--- a/CRISPResso2/CRISPRessoBatchCORE.py
+++ b/CRISPResso2/CRISPRessoBatchCORE.py
@@ -83,7 +83,7 @@ def main():
         CRISPRessoShared.check_file(args.batch_settings)
 
         if args.zip_output and not args.place_report_in_output_folder:
-            logger.warn('Invalid arguement combination: If zip_output is True then place_report_in_output_folder must also be True. Setting place_report_in_output_folder to True.')
+            warn('Invalid arguement combination: If zip_output is True then place_report_in_output_folder must also be True. Setting place_report_in_output_folder to True.')
             args.place_report_in_output_folder = True
 
         batch_folder_name = os.path.splitext(os.path.basename(args.batch_settings))[0]
@@ -113,6 +113,8 @@ def main():
 
         log_filename = _jp('CRISPRessoBatch_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
+        status_handler = CRISPRessoShared.StatusHandler(_jp('status.txt'))
+        logger.addHandler(status_handler)
 
         with open(log_filename, 'w+') as outfile:
             outfile.write('[Command used]:\n%s\n\n[Execution log]:\n' % ' '.join(sys.argv))

--- a/CRISPResso2/CRISPRessoBatchCORE.py
+++ b/CRISPResso2/CRISPRessoBatchCORE.py
@@ -70,6 +70,8 @@ def main():
 
         args = parser.parse_args()
 
+        CRISPRessoShared.set_console_log_level(logger, args.verbosity, args.debug)
+
         debug_flag = args.debug
 
         crispresso_options = CRISPRessoShared.get_crispresso_options()

--- a/CRISPResso2/CRISPRessoBatchCORE.py
+++ b/CRISPResso2/CRISPRessoBatchCORE.py
@@ -18,15 +18,11 @@ from CRISPResso2 import CRISPRessoMultiProcessing
 from CRISPResso2 import CRISPRessoReport
 
 import logging
-logging.basicConfig(
-                     format='%(levelname)-5s @ %(asctime)s:\n\t %(message)s \n',
-                     datefmt='%a, %d %b %Y %H:%M:%S',
-                     stream=sys.stderr,
-                     filemode="w"
-                     )
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(CRISPRessoShared.LogStreamHandler())
+
 error   = logger.critical
 warn    = logger.warning
 debug   = logger.debug

--- a/CRISPResso2/CRISPRessoBatchCORE.py
+++ b/CRISPResso2/CRISPRessoBatchCORE.py
@@ -876,7 +876,7 @@ def main():
             crispresso2Batch_info_file,
             crispresso2_info,
         )
-        info('Analysis Complete!')
+        info('Analysis Complete!', {'percent_complete': 100})
         if args.zip_output:
             if args.output_folder == "":
                 path_value = os.path.split(OUTPUT_DIRECTORY)

--- a/CRISPResso2/CRISPRessoBatchCORE.py
+++ b/CRISPResso2/CRISPRessoBatchCORE.py
@@ -280,7 +280,7 @@ def main():
         crispresso2_info['results']['batch_names_arr'] = batch_names_arr
         crispresso2_info['results']['batch_input_names'] = batch_input_names
 
-        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes_for_batch, 'batch', args.skip_failed, start_end_percent=[10, 90])
+        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, n_processes_for_batch, 'batch', args.skip_failed, start_end_percent=[10, 90])
 
         run_datas = [] # crispresso2 info from each row
 

--- a/CRISPResso2/CRISPRessoBatchCORE.py
+++ b/CRISPResso2/CRISPRessoBatchCORE.py
@@ -104,10 +104,10 @@ def main():
         _jp = lambda filename: os.path.join(OUTPUT_DIRECTORY, filename) #handy function to put a file in the output directory
 
         try:
-                 info('Creating Folder %s' % OUTPUT_DIRECTORY)
-                 os.makedirs(OUTPUT_DIRECTORY)
+            info('Creating Folder %s' % OUTPUT_DIRECTORY, {'percent_complete': 0})
+            os.makedirs(OUTPUT_DIRECTORY)
         except:
-                 warn('Folder %s already exists.' % OUTPUT_DIRECTORY)
+            warn('Folder %s already exists.' % OUTPUT_DIRECTORY)
 
         log_filename = _jp('CRISPRessoBatch_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
@@ -280,7 +280,7 @@ def main():
         crispresso2_info['results']['batch_names_arr'] = batch_names_arr
         crispresso2_info['results']['batch_input_names'] = batch_input_names
 
-        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, n_processes_for_batch, 'batch', args.skip_failed)
+        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes_for_batch, 'batch', args.skip_failed)
 
         run_datas = [] # crispresso2 info from each row
 

--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -1019,7 +1019,7 @@ def main():
             with open(log_filename, 'w+') as outfile:
                 outfile.write('CRISPResso version %s\n[Command used]:\n%s\n\n[Execution log]:\n' %(CRISPRessoShared.__version__, crispresso_cmd_to_write))
 
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('status.txt')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPResso_status.txt')))
 
         aln_matrix_loc = os.path.join(_ROOT, "EDNAFULL")
         CRISPRessoShared.check_file(aln_matrix_loc)

--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -1008,7 +1008,7 @@ def main():
         crispresso_cmd_to_write = ' '.join(sys.argv)
         try:
             os.makedirs(OUTPUT_DIRECTORY)
-            info('Creating Folder %s' % OUTPUT_DIRECTORY)
+            info('Creating Folder %s' % OUTPUT_DIRECTORY, {'percent_complete': 0})
 #            info('Done!') #crispresso2 doesn't announce that the folder is created... save some electricity here
         except:
             warn('Folder %s already exists.' % OUTPUT_DIRECTORY)
@@ -1097,7 +1097,7 @@ def main():
                             args_are_same = False
 
                     if args_are_same:
-                        info('Analysis already completed on %s!'%previous_run_data['running_info']['end_time_string'])
+                        info('Analysis already completed on %s!'%previous_run_data['running_info']['end_time_string'], {'percent_complete': 100})
                         sys.exit(0)
                 else:
                     info('The no_rerun flag is set, but this analysis will be rerun because the existing run was performed using an old version of CRISPResso (' + str(previous_run_data['running_info']['version']) + ').')
@@ -1189,7 +1189,7 @@ def main():
         if args.auto:
             number_of_reads_to_consider = 5000
 
-            info('Inferring reference amplicon sequence..')
+            info('Inferring reference amplicon sequence..', {'percent_complete': 1})
 
             auto_fastq_r1 = args.fastq_r1 #paths to fastq files for performing auto functions
             auto_fastq_r2 = args.fastq_r2
@@ -1547,6 +1547,8 @@ def main():
         #end prime editing guide function
 
         #now that we're done with adding possible guides and amplicons, go through each amplicon and compute quantification windows
+        info('Computing quantification windows', {'percent_complete': 2})
+
         found_guide_seq = [False]*len(guides)
         found_coding_seq = [False]*len(coding_seqs)
 
@@ -1629,7 +1631,7 @@ def main():
                             this_guide_plot_cut_points.append(False)
                         else:
                             this_guide_plot_cut_points.append(True)
-                info('Added %d guides with flexible matching\n\tOriginal flexiguides: %s\n\tFound guides: %s\n\tMismatch locations: %s'%(flexi_guide_count, str(args.flexiguide_seq.split(",")), str(flexi_guides), str(flexi_guide_mismatches)))
+                info('Added %d guides with flexible matching\n\tOriginal flexiguides: %s\n\tFound guides: %s\n\tMismatch locations: %s'%(flexi_guide_count, str(args.flexiguide_seq.split(",")), str(flexi_guides), str(flexi_guide_mismatches)), {'percent_complete': 7})
 
             if args.prime_editing_pegRNA_extension_seq:
                 nicking_qw_center = int(args.quantification_window_center.split(",")[0])
@@ -2063,7 +2065,7 @@ def main():
                 files_to_remove+=[args.fastq_r1, args.fastq_r2]
                 N_READS_INPUT = N_READS_INPUT/2
 
-                info('Done!')
+                info('Done!', {'percent_complete': 4})
 
         if args.min_average_read_quality>0 or args.min_single_bp_quality>0 or args.min_bp_quality_or_N>0:
             if args.bam_input != '':
@@ -2154,7 +2156,7 @@ def main():
                 files_to_remove += [output_forward_paired_filename]
                 files_to_remove += [output_reverse_paired_filename]
 
-                info('Done!')
+                info('Done!', {'percent_complete': 6})
 
             #for paired-end reads, merge them
             info('Estimating average read length...')
@@ -2239,7 +2241,7 @@ def main():
                  if args.debug:
                      info('Wrote force-merged reads to ' + new_merged_filename)
 
-            info('Done!')
+            info('Done!', {'percent_complete': 7})
 
 
         #count reads
@@ -2271,7 +2273,7 @@ def main():
         else:
             aln_stats = process_fastq(processed_output_filename, variantCache, ref_names, refs, args)
 
-        info('Done!')
+        info('Done!', {'percent_complete': 20})
 
         if args.prime_editing_pegRNA_scaffold_seq != "":
             #introduce a new ref (that we didn't align to) called 'Scaffold Incorporated' -- copy it from the ref called 'prime-edited'
@@ -2810,7 +2812,7 @@ def main():
                         nuc = aln_seq[i]
                         ref1_all_base_count_vectors[ref_name + "_" + nuc][ref_pos[i]] += variant_count
 
-        info('Done!')
+        info('Done!', {'percent_complete': 30})
 
         #order class_counts
         decorated_class_counts = []
@@ -2962,7 +2964,7 @@ def main():
 
                 insertion_length_vectors[ref_name] = np.zeros(ref_len)
 
-        info('Done!')
+        info('Done!', {'percent_complete': 40})
 
         if args.dump:
             ref_info_file_name = _jp('CRISPResso_reference_info.txt')
@@ -3378,6 +3380,7 @@ def main():
                 'plot_root': plot_1a_root,
                 'save_png': save_png
             }
+            info('Plotting read bar plot', {'percent_complete': 42})
             plot(CRISPRessoPlot.plot_read_barplot, plot_1a_input)
             crispresso2_info['results']['general_plots']['plot_1a_root'] = os.path.basename(plot_1a_root)
             crispresso2_info['results']['general_plots']['plot_1a_caption'] = "Figure 1a: The number of reads in input fastqs, after preprocessing, and after alignment to amplicons."
@@ -3404,6 +3407,7 @@ def main():
             crispresso2_info['results']['general_plots']['plot_1c_root'] = os.path.basename(plot_1c_root)
             crispresso2_info['results']['general_plots']['plot_1c_caption'] = "Figure 1c: Alignment and editing frequency of reads as determined by the percentage and number of sequence reads showing unmodified and modified alleles."
             crispresso2_info['results']['general_plots']['plot_1c_data'] = [('Quantification of editing', os.path.basename(quant_of_editing_freq_filename))]
+            info('Plotting read class pie chart and bar plot', {'percent_complete': 44})
             plot(CRISPRessoPlot.plot_class_piechart_and_barplot, plot_1bc_input)
             # to test, run: plot_pool.apply_async(CRISPRessoPlot.plot_class_piechart_and_barplot, kwds=plot_1bc_input).get()
 
@@ -3424,6 +3428,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
+                info('Plotting dsODN pie chart', {'percent_complete': 46})
                 plot(CRISPRessoPlot.plot_class_dsODN_piechart, plot_1d_input)
 
                 crispresso2_info['results']['general_plots']['plot_1d_root'] = os.path.basename(plot_root)
@@ -3434,7 +3439,9 @@ def main():
         #hold mod pct dfs for each amplicon/guide
         mod_pct_dfs = {}
 
-        for ref_name in ref_names:
+        ref_percent_complete_start, ref_percent_complete_end = 48, 88
+        ref_percent_complete_step = (ref_percent_complete_end - ref_percent_complete_start) / float(len(ref_names))
+        for ref_index, ref_name in enumerate(ref_names):
             ref_len = refs[ref_name]['sequence_length']
             ref_seq = refs[ref_name]['sequence']
             min_cut = refs[ref_name]['min_cut']
@@ -3456,6 +3463,14 @@ def main():
 
             #only show reference name in filenames if more than one reference
             ref_plot_name = refs[ref_name]['ref_plot_name']
+
+            # this is determined by the number of times the percent_complete is updated
+            num_sgRNA_steps = 5
+            num_ref_steps = 16 + (len(sgRNA_sequences) * num_sgRNA_steps)
+            ref_percent_complete_increment = ref_percent_complete_step / float(num_ref_steps)
+            percent_complete = ref_percent_complete_start + (ref_percent_complete_step * ref_index)
+            info('Begin processing amplicon {0}'.format(ref_name), {'percent_complete': percent_complete})
+
 
             if n_this_category < 1:
                 continue
@@ -3543,6 +3558,8 @@ def main():
                         'sgRNA_mismatches': sgRNA_mismatches,
                         'quantification_window_idxs': include_idxs_list,
                     }
+                    percent_complete += ref_percent_complete_increment
+                    info('Plotting nucleotide quilt across amplicon', {'percent_complete': percent_complete})
                     plot(CRISPRessoPlot.plot_nucleotide_quilt, plot_2a_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_2a_root'] = os.path.basename(plot_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_2a_caption'] = "Figure 2a: Nucleotide distribution across amplicon. At each base in the reference amplicon, the percentage of each base as observed in sequencing reads is shown (A = green; C = orange; G = yellow; T = purple). Black bars show the percentage of reads for which that base was deleted. Brown bars between bases show the percentage of reads having an insertion at that position."
@@ -3588,6 +3605,8 @@ def main():
                             'sgRNA_mismatches': sgRNA_mismatches,
                             'quantification_window_idxs': new_include_idx,
                         }
+                        percent_complete += ((i + 1) / len(cut_points)) * ref_percent_complete_increment
+                        info('Plotting nucleotide distribuition around {0}'.format(sgRNA_legend), {'percent_complete': percent_complete})
                         plot(CRISPRessoPlot.plot_nucleotide_quilt, plot_2b_input)
                         crispresso2_info['results']['refs'][ref_name]['plot_2b_roots'].append(os.path.basename(plot_root))
                         crispresso2_info['results']['refs'][ref_name]['plot_2b_captions'].append('Figure 2b: Nucleotide distribution around the ' + sgRNA_legend + '.')
@@ -3638,6 +3657,8 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
+                percent_complete += ref_percent_complete_increment
+                info('Plotting indel size distribution', {'percent_complete': percent_complete})
                 plot(CRISPRessoPlot.plot_indel_size_distribution, plot_3a_input)
                 clipped_string = ""
                 if xmax < max(hlengths):
@@ -3718,6 +3739,8 @@ def main():
                     'xmax_mut': xmax_mut,
                     'save_also_png': save_png,
                 }
+                percent_complete += ref_percent_complete_increment
+                info('Plotting frequency deletions/insertions', {'percent_complete': percent_complete})
                 plot(CRISPRessoPlot.plot_frequency_deletions_insertions, plot_3b_input)
 
                 if clipped_string != "":
@@ -3763,6 +3786,8 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
+                percent_complete += ref_percent_complete_increment
+                info('Plotting amplication modifications', {'percent_complete': percent_complete})
                 plot(CRISPRessoPlot.plot_amplicon_modifications, plot_4a_input)
                 crispresso2_info['results']['refs'][ref_name]['plot_4a_root'] = os.path.basename(plot_root)
                 crispresso2_info['results']['refs'][ref_name]['plot_4a_caption'] = "Figure 4a: Combined frequency of any modification across the amplicon. Modifications outside of the quantification window are also shown."
@@ -3791,6 +3816,8 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
+                percent_complete += ref_percent_complete_increment
+                info('Plotting modification frequency', {'percent_complete': percent_complete})
                 plot(CRISPRessoPlot.plot_modification_frequency, plot_4b_input)
                 crispresso2_info['results']['refs'][ref_name]['plot_4b_root'] = os.path.basename(plot_root)
                 crispresso2_info['results']['refs'][ref_name]['plot_4b_caption'] = "Figure 4b: Frequency of insertions (red), deletions (purple), and substitutions (green) across the entire amplicon, including modifications outside of the quantification window."
@@ -3818,6 +3845,8 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
+                percent_complete += ref_percent_complete_increment
+                info('Plotting quantification window locations', {'percent_complete': percent_complete})
                 plot(
                     CRISPRessoPlot.plot_quantification_window_locations,
                     plot_4c_input,
@@ -3847,6 +3876,8 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
+                percent_complete += ref_percent_complete_increment
+                info('Plotting position dependent indel', {'percent_complete': percent_complete})
                 plot(
                     CRISPRessoPlot.plot_position_dependent_indels,
                     plot_4d_input,
@@ -3886,6 +3917,8 @@ def main():
                         crispresso2_info['results']['refs'][ref_names[0]]['plot_4f_root'] = os.path.basename(plot_root)
                         crispresso2_info['results']['refs'][ref_names[0]]['plot_4f_caption'] = "Figure 4f: Positions of modifications in HDR reads with respect to the reference sequence ("+ref_names[0]+"). Insertions: red, deletions: purple, substitutions: green. All modifications (including those outside the quantification window) are shown."
                         crispresso2_info['results']['refs'][ref_names[0]]['plot_4f_data'] = []
+                    percent_complete += ref_percent_complete_increment
+                    info('Plotting global modifications with respect to reference', {'percent_complete': percent_complete})
                     plot(
                         CRISPRessoPlot.plot_global_modifications_reference,
                         plot_4e_input,
@@ -3939,6 +3972,8 @@ def main():
                         'sgRNA_names': sgRNA_names,
                         'sgRNA_mismatches': sgRNA_mismatches,
                     }
+                    percent_complete += ref_percent_complete_increment
+                    info('Plotting HDR nucleotide quilt', {'percent_complete': percent_complete})
                     plot(CRISPRessoPlot.plot_nucleotide_quilt, plot_4g_input)
                     crispresso2_info['results']['refs'][ref_names_for_hdr[0]]['plot_4g_root'] = os.path.basename(plot_root)
                     crispresso2_info['results']['refs'][ref_names_for_hdr[0]]['plot_4g_caption'] = "Figure 4g: Nucleotide distribution across all amplicons. At each base in the reference amplicon, the percentage of each base as observed in sequencing reads is shown (A = green; C = orange; G = yellow; T = purple). Black bars show the percentage of reads for which that base was deleted. Brown bars between bases show the percentage of reads having an insertion at that position."
@@ -3986,6 +4021,8 @@ def main():
                             'plot_root': plot_root,
                             'save_also_png': save_png,
                         }
+                        percent_complete += ref_percent_complete_increment
+                        info('Plotting frameshift analysis', {'percent_complete': percent_complete})
                         plot(CRISPRessoPlot.plot_frameshift_analysis, plot_5_input)
                         crispresso2_info['results']['refs'][ref_name]['plot_5_root'] = os.path.basename(plot_root)
                         crispresso2_info['results']['refs'][ref_name]['plot_5_caption'] = "Figure 5: Frameshift analysis of coding sequence reads affected by modifications (unmodified reads are excluded from this analysis)."
@@ -4010,6 +4047,8 @@ def main():
                         'plot_root': plot_root,
                         'save_also_png': save_png,
                     }
+                    percent_complete += ref_percent_complete_increment
+                    info('Plotting frameshift frequency', {'percent_complete': percent_complete})
                     plot(CRISPRessoPlot.plot_frameshift_frequency, plot_6_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_6_root'] = os.path.basename(plot_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_6_caption'] = "Figure 6: Frameshift and in-frame mutagenesis profiles indicating position affected by modification. The y axis shows the number of reads and percentage of all reads in that category (frameshifted (top) or in-frame (bottom)). %d reads with no length modifications are not shown."%hists_inframe[ref_name][0]
@@ -4037,6 +4076,8 @@ def main():
                         'plot_root': plot_root,
                         'save_also_png': save_png,
                     }
+                    percent_complete += ref_percent_complete_increment
+                    info('Plotting non-coding mutation positions', {'percent_complete': percent_complete})
                     plot(CRISPRessoPlot.plot_non_coding_mutations, plot_7_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_7_root'] = os.path.basename(plot_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_7_caption'] = "Figure 7: Reads with insertions (red), deletions (purple), and substitutions (green) mapped to reference amplicon position exclusively in noncoding region/s (that is, without mutations affecting coding sequences). The predicted cleavage site is indicated by a vertical dashed line. Only sequence positions directly adjacent to insertions or directly affected by deletions or substitutions are plotted."
@@ -4049,6 +4090,8 @@ def main():
                         'plot_root': plot_root,
                         'save_also_png': save_png,
                     }
+                    percent_complete += ref_percent_complete_increment
+                    info('Plotting potential splice sites', {'percent_complete': percent_complete})
                     plot(CRISPRessoPlot.plot_potential_splice_sites, plot_8_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_8_root'] = os.path.basename(plot_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_8_caption'] = "Figure 8: Predicted impact on splice sites. Potential splice sites modified refers to reads in which the either of the two intronic positions adjacent to exon junctions are disrupted."
@@ -4073,6 +4116,8 @@ def main():
                         'save_also_png': save_png,
                         'quantification_window_idxs': include_idxs_list,
                     }
+                    percent_complete += ref_percent_complete_increment
+                    info('Plotting substitutions across reference', {'percent_complete': percent_complete})
                     plot(CRISPRessoPlot.plot_subs_across_ref, plot_10a_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_10a_root'] = os.path.basename(fig_filename_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_10a_caption'] = "Figure 10a: Substitution frequencies across the amplicon."
@@ -4090,6 +4135,8 @@ def main():
                         'fig_filename_root': fig_filename_root,
                         'save_also_png': save_png
                     }
+                    percent_complete += ref_percent_complete_increment
+                    info('Plotting substitution frequency barplot', {'percent_complete': percent_complete})
                     plot(CRISPRessoPlot.plot_sub_freqs, plot_10b_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_10b_root'] = os.path.basename(fig_filename_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_10b_caption'] = "Figure 10b: Substitution frequencies across the amplicon."
@@ -4103,6 +4150,8 @@ def main():
                         'fig_filename_root': fig_filename_root,
                         'save_also_png': save_png
                     }
+                    percent_complete += ref_percent_complete_increment
+                    info('Plotting substitution frequency barplot in quantification window', {'percent_complete': percent_complete})
                     plot(CRISPRessoPlot.plot_sub_freqs, plot_10c_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_10c_root'] = os.path.basename(fig_filename_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_10c_caption'] = "Figure 10c: Substitution frequencies in the quantification window"
@@ -4138,12 +4187,12 @@ def main():
             crispresso2_info['results']['refs'][ref_name]['plot_10g_captions'] = []
             crispresso2_info['results']['refs'][ref_name]['plot_10g_datas'] = []
 
-            for ind, sgRNA_seq in enumerate(sgRNA_sequences):
-                cut_point = sgRNA_cut_points[ind]
-                plot_cut_point = sgRNA_plot_cut_points[ind]
-                sgRNA_name = sgRNA_names[ind]
-                plot_idxs = sgRNA_plot_idxs[ind]
-                sgRNA = sgRNA_orig_sequences[ind]
+            for sgRNA_ind, sgRNA_seq in enumerate(sgRNA_sequences):
+                cut_point = sgRNA_cut_points[sgRNA_ind]
+                plot_cut_point = sgRNA_plot_cut_points[sgRNA_ind]
+                sgRNA_name = sgRNA_names[sgRNA_ind]
+                plot_idxs = sgRNA_plot_idxs[sgRNA_ind]
+                sgRNA = sgRNA_orig_sequences[sgRNA_ind]
 
                 sgRNA_label = "sgRNA_"+sgRNA # for file names
                 sgRNA_legend = "sgRNA " + sgRNA # for legends
@@ -4192,6 +4241,8 @@ def main():
                         'sgRNA_mismatches': sgRNA_mismatches,
                         'annotate_wildtype_allele': args.annotate_wildtype_allele,
                     }
+                    percent_complete += ref_percent_complete_increment
+                    info('Plotting allele distribution around cut', {'percent_complete': percent_complete})
                     plot(CRISPRessoPlot.plot_alleles_table, plot_9_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_9_roots'].append(os.path.basename(fig_filename_root))
                     crispresso2_info['results']['refs'][ref_name]['plot_9_captions'].append("Figure 9: Visualization of the distribution of identified alleles around the cleavage site for the " + sgRNA_legend + ". Nucleotides are indicated by unique colors (A = green; C = red; G = yellow; T = purple). Substitutions are shown in bold font. Red rectangles highlight inserted sequences. Horizontal dashed lines indicate deleted sequences. The vertical dashed line indicates the predicted cleavage site.")
@@ -4205,14 +4256,14 @@ def main():
 
                     #get computation window in plotted region
                     is_window = np.zeros(ref_len)
-                    for ind in include_idxs_list:
-                        is_window[ind] = 1
+                    for include_idx in include_idxs_list:
+                        is_window[include_idx] = 1
                     plot_is_window = np.zeros(len(plot_idxs)) #binary array whether base should be plotted
                     plot_quant_window_idxs = []
-                    for ind, loc in enumerate(plot_idxs):
-                        plot_is_window[ind] = is_window[loc]
+                    for plot_ind, loc in enumerate(plot_idxs):
+                        plot_is_window[plot_ind] = is_window[loc]
                         if is_window[loc]:
-                            plot_quant_window_idxs.append(ind-2)
+                            plot_quant_window_idxs.append(plot_ind-2)
 
                     from_nuc_indices = [pos for pos, char in enumerate(list(plot_nuc_pcts.columns.values)) if char == args.conversion_nuc_from]
                     just_sel_nuc_pcts = plot_nuc_pcts.iloc[:, from_nuc_indices].copy() #only nucleotides targeted by base editing
@@ -4256,6 +4307,8 @@ def main():
                             'save_also_png': save_png,
                             'quantification_window_idxs': plot_quant_window_idxs,
                         }
+                        percent_complete += ref_percent_complete_increment
+                        info('Plotting log2 nucleotide frequency', {'percent_complete': percent_complete})
                         plot(CRISPRessoPlot.plot_log_nuc_freqs, plot_10d_input)
                         crispresso2_info['results']['refs'][ref_name]['plot_10d_roots'].append(os.path.basename(fig_filename_root))
                         crispresso2_info['results']['refs'][ref_name]['plot_10d_captions'].append("Figure 10d: Log2 nucleotide frequencies for each position in the plotting window around the " + sgRNA_legend + ". The quantification window is outlined by the dotted box.")
@@ -4276,6 +4329,8 @@ def main():
                             'fig_filename_root': fig_filename_root,
                             'save_also_png': save_png,
                         }
+                        percent_complete += ref_percent_complete_increment
+                        info('Plotting conversion at {0}s around the {1}'.format(args.conversion_nuc_from, sgRNA_legend), {'percent_complete': percent_complete})
                         plot(
                             CRISPRessoPlot.plot_conversion_at_sel_nucs,
                             plot_10e_input,
@@ -4294,6 +4349,8 @@ def main():
                             'fig_filename_root': fig_filename_root,
                             'save_also_png': save_png,
                         }
+                        percent_complete += ref_percent_complete_increment
+                        info('Plotting non-reference conversion at {0}s around the {1}'.format(args.conversion_nuc_from, sgRNA_legend), {'percent_complete': percent_complete})
                         plot(
                             CRISPRessoPlot.plot_conversion_at_sel_nucs_not_include_ref,
                             plot_10f_input,
@@ -4315,6 +4372,8 @@ def main():
                             'fig_filename_root': fig_filename_root,
                             'save_also_png': save_png
                         }
+                        percent_complete += ref_percent_complete_increment
+                        info('Plotting scaled non-reference conversion at {0}s around the {1}'.format(args.conversion_nuc_from, sgRNA_legend), {'percent_complete': percent_complete})
                         plot(
                             CRISPRessoPlot.plot_conversion_at_sel_nucs_not_include_ref_scaled,
                             plot_10g_input,
@@ -4378,6 +4437,7 @@ def main():
                         'plot_root': plot_root,
                         'save_also_png': save_png,
                     }
+                    info('Plotting global frameshift in-frame mutations pie chart', {'percent_complete': 90})
                     plot(
                         CRISPRessoPlot.plot_global_frameshift_analysis,
                         plot_5a_input,
@@ -4394,6 +4454,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
+                info('Plotting global frameshift in-frame mutation profiles', {'percent_complete': 92})
                 plot(
                     CRISPRessoPlot.plot_global_frameshift_in_frame_mutations,
                     plot_6a_input,
@@ -4415,6 +4476,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
+                info('Plotting global potential splice sites pie chart', {'percent_complete': 94})
                 plot(CRISPRessoPlot.plot_impact_on_splice_sites, plot_8a_input)
                 crispresso2_info['results']['general_plots']['plot_8a_root'] = os.path.basename(plot_root)
                 crispresso2_info['results']['general_plots']['plot_8a_caption'] = "Figure 8a: Predicted impact on splice sites for all reads. Potential splice sites modified refers to reads in which the either of the two intronic positions adjacent to exon junctions are disrupted."
@@ -4500,6 +4562,7 @@ def main():
                     'sgRNA_mismatches': sgRNA_mismatches,
                     'quantification_window_idxs': include_idxs_list,
                 }
+                info('Plotting prime editing nucleotide percentage quilt', {'percent_complete': 96})
                 plot(CRISPRessoPlot.plot_nucleotide_quilt, plot_11a_input)
                 crispresso2_info['results']['refs'][ref_names_for_pe[0]]['plot_11a_root'] = os.path.basename(plot_root)
                 crispresso2_info['results']['refs'][ref_names_for_pe[0]]['plot_11a_caption'] = "Figure 11a: Nucleotide distribution across all amplicons. At each base in the reference amplicon, the percentage of each base as observed in sequencing reads is shown (A = green; C = orange; G = yellow; T = purple). Black bars show the percentage of reads for which that base was deleted. Brown bars between bases show the percentage of reads having an insertion at that position."
@@ -4557,6 +4620,7 @@ def main():
                         'sgRNA_mismatches': sgRNA_mismatches,
                         'quantification_window_idxs': new_include_idx,
                     }
+                    info('Plotting nucleotide quilt', {'percent_complete': 97})
                     plot(CRISPRessoPlot.plot_nucleotide_quilt, plot_11b_input)
                     crispresso2_info['results']['refs'][ref_names_for_pe[0]]['plot_11b_roots'].append(os.path.basename(plot_root))
                     crispresso2_info['results']['refs'][ref_names_for_pe[0]]['plot_11b_captions'].append('Figure 11b: Nucleotide distribution around the ' + sgRNA_legend + '.')
@@ -4569,6 +4633,7 @@ def main():
                         'plot_root': plot_root,
                         'save_also_png': save_png,
                     }
+                    info('Plotting scaffold insertion sizes', {'percent_complete': 98})
                     plot(
                         CRISPRessoPlot.plot_scaffold_indel_lengths,
                         plot_11c_input,

--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -987,6 +987,8 @@ def main():
         arg_parser = CRISPRessoShared.getCRISPRessoArgParser()
         args = arg_parser.parse_args()
 
+        CRISPRessoShared.set_console_log_level(logger, args.verbosity, args.debug)
+
         OUTPUT_DIRECTORY = 'CRISPResso_on_{0}'.format(normalize_name(args))
 
         if args.output_folder:

--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -43,15 +43,9 @@ present = datetime.now()
 
 import logging
 
-logging.basicConfig(
-                     format='%(levelname)-5s @ %(asctime)s:\n\t %(message)s \n',
-                     datefmt='%a, %d %b %Y %H:%M:%S',
-                     stream=sys.stderr,
-                     filemode="w"
-                     )
-
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(CRISPRessoShared.LogStreamHandler())
 
 error   = logger.critical
 warn    = logger.warning
@@ -979,6 +973,8 @@ def main():
         if debug_flag:
             traceback.print_exc(file=sys.stdout)
             error(traceback.format_exc())
+        else:
+            debug(traceback.format_exc())
 
     try:
 

--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -3613,7 +3613,7 @@ def main():
                             'sgRNA_mismatches': sgRNA_mismatches,
                             'quantification_window_idxs': new_include_idx,
                         }
-                        debug('Plotting nucleotide distribuition around {0}'.format(sgRNA_legend))
+                        debug('Plotting nucleotide distribuition around {0} for {1}'.format(sgRNA_legend, ref_name))
                         plot(CRISPRessoPlot.plot_nucleotide_quilt, plot_2b_input)
                         crispresso2_info['results']['refs'][ref_name]['plot_2b_roots'].append(os.path.basename(plot_root))
                         crispresso2_info['results']['refs'][ref_name]['plot_2b_captions'].append('Figure 2b: Nucleotide distribution around the ' + sgRNA_legend + '.')
@@ -3664,7 +3664,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
-                debug('Plotting indel size distribution')
+                debug('Plotting indel size distribution for {0}'.format(ref_name))
                 plot(CRISPRessoPlot.plot_indel_size_distribution, plot_3a_input)
                 clipped_string = ""
                 if xmax < max(hlengths):
@@ -3745,7 +3745,7 @@ def main():
                     'xmax_mut': xmax_mut,
                     'save_also_png': save_png,
                 }
-                debug('Plotting frequency deletions/insertions')
+                debug('Plotting frequency deletions/insertions for {0}'.format(ref_name))
                 plot(CRISPRessoPlot.plot_frequency_deletions_insertions, plot_3b_input)
 
                 if clipped_string != "":
@@ -3791,7 +3791,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
-                debug('Plotting amplication modifications')
+                debug('Plotting amplication modifications for {0}'.format(ref_name))
                 plot(CRISPRessoPlot.plot_amplicon_modifications, plot_4a_input)
                 crispresso2_info['results']['refs'][ref_name]['plot_4a_root'] = os.path.basename(plot_root)
                 crispresso2_info['results']['refs'][ref_name]['plot_4a_caption'] = "Figure 4a: Combined frequency of any modification across the amplicon. Modifications outside of the quantification window are also shown."
@@ -3820,7 +3820,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
-                debug('Plotting modification frequency')
+                debug('Plotting modification frequency for {0}'.format(ref_name))
                 plot(CRISPRessoPlot.plot_modification_frequency, plot_4b_input)
                 crispresso2_info['results']['refs'][ref_name]['plot_4b_root'] = os.path.basename(plot_root)
                 crispresso2_info['results']['refs'][ref_name]['plot_4b_caption'] = "Figure 4b: Frequency of insertions (red), deletions (purple), and substitutions (green) across the entire amplicon, including modifications outside of the quantification window."
@@ -3848,7 +3848,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
-                debug('Plotting quantification window locations')
+                debug('Plotting quantification window locations for {0}'.format(ref_name))
                 plot(
                     CRISPRessoPlot.plot_quantification_window_locations,
                     plot_4c_input,
@@ -3878,7 +3878,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
-                debug('Plotting position dependent indel')
+                debug('Plotting position dependent indel for {0}'.format(ref_name))
                 plot(
                     CRISPRessoPlot.plot_position_dependent_indels,
                     plot_4d_input,
@@ -4020,7 +4020,7 @@ def main():
                             'plot_root': plot_root,
                             'save_also_png': save_png,
                         }
-                        debug('Plotting frameshift analysis')
+                        debug('Plotting frameshift analysis for {0}'.format(ref_name))
                         plot(CRISPRessoPlot.plot_frameshift_analysis, plot_5_input)
                         crispresso2_info['results']['refs'][ref_name]['plot_5_root'] = os.path.basename(plot_root)
                         crispresso2_info['results']['refs'][ref_name]['plot_5_caption'] = "Figure 5: Frameshift analysis of coding sequence reads affected by modifications (unmodified reads are excluded from this analysis)."
@@ -4045,7 +4045,7 @@ def main():
                         'plot_root': plot_root,
                         'save_also_png': save_png,
                     }
-                    debug('Plotting frameshift frequency')
+                    debug('Plotting frameshift frequency for {0}'.format(ref_name))
                     plot(CRISPRessoPlot.plot_frameshift_frequency, plot_6_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_6_root'] = os.path.basename(plot_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_6_caption'] = "Figure 6: Frameshift and in-frame mutagenesis profiles indicating position affected by modification. The y axis shows the number of reads and percentage of all reads in that category (frameshifted (top) or in-frame (bottom)). %d reads with no length modifications are not shown."%hists_inframe[ref_name][0]
@@ -4073,7 +4073,7 @@ def main():
                         'plot_root': plot_root,
                         'save_also_png': save_png,
                     }
-                    debug('Plotting non-coding mutation positions')
+                    debug('Plotting non-coding mutation positions for {0}'.format(ref_name))
                     plot(CRISPRessoPlot.plot_non_coding_mutations, plot_7_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_7_root'] = os.path.basename(plot_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_7_caption'] = "Figure 7: Reads with insertions (red), deletions (purple), and substitutions (green) mapped to reference amplicon position exclusively in noncoding region/s (that is, without mutations affecting coding sequences). The predicted cleavage site is indicated by a vertical dashed line. Only sequence positions directly adjacent to insertions or directly affected by deletions or substitutions are plotted."
@@ -4111,7 +4111,7 @@ def main():
                         'save_also_png': save_png,
                         'quantification_window_idxs': include_idxs_list,
                     }
-                    debug('Plotting substitutions across reference')
+                    debug('Plotting substitutions across reference for {0}'.format(ref_name))
                     plot(CRISPRessoPlot.plot_subs_across_ref, plot_10a_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_10a_root'] = os.path.basename(fig_filename_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_10a_caption'] = "Figure 10a: Substitution frequencies across the amplicon."
@@ -4129,7 +4129,7 @@ def main():
                         'fig_filename_root': fig_filename_root,
                         'save_also_png': save_png
                     }
-                    debug('Plotting substitution frequency barplot')
+                    debug('Plotting substitution frequency barplot for {0}'.format(ref_name))
                     plot(CRISPRessoPlot.plot_sub_freqs, plot_10b_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_10b_root'] = os.path.basename(fig_filename_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_10b_caption'] = "Figure 10b: Substitution frequencies across the amplicon."
@@ -4143,7 +4143,7 @@ def main():
                         'fig_filename_root': fig_filename_root,
                         'save_also_png': save_png
                     }
-                    debug('Plotting substitution frequency barplot in quantification window')
+                    debug('Plotting substitution frequency barplot in quantification window for {0}'.format(ref_name))
                     plot(CRISPRessoPlot.plot_sub_freqs, plot_10c_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_10c_root'] = os.path.basename(fig_filename_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_10c_caption'] = "Figure 10c: Substitution frequencies in the quantification window"
@@ -4233,7 +4233,7 @@ def main():
                         'sgRNA_mismatches': sgRNA_mismatches,
                         'annotate_wildtype_allele': args.annotate_wildtype_allele,
                     }
-                    debug('Plotting allele distribution around cut')
+                    debug('Plotting allele distribution around cut for {0}'.format(ref_name))
                     plot(CRISPRessoPlot.plot_alleles_table, plot_9_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_9_roots'].append(os.path.basename(fig_filename_root))
                     crispresso2_info['results']['refs'][ref_name]['plot_9_captions'].append("Figure 9: Visualization of the distribution of identified alleles around the cleavage site for the " + sgRNA_legend + ". Nucleotides are indicated by unique colors (A = green; C = red; G = yellow; T = purple). Substitutions are shown in bold font. Red rectangles highlight inserted sequences. Horizontal dashed lines indicate deleted sequences. The vertical dashed line indicates the predicted cleavage site.")
@@ -4298,7 +4298,7 @@ def main():
                             'save_also_png': save_png,
                             'quantification_window_idxs': plot_quant_window_idxs,
                         }
-                        debug('Plotting log2 nucleotide frequency')
+                        debug('Plotting log2 nucleotide frequency for {0}'.format(ref_name))
                         plot(CRISPRessoPlot.plot_log_nuc_freqs, plot_10d_input)
                         crispresso2_info['results']['refs'][ref_name]['plot_10d_roots'].append(os.path.basename(fig_filename_root))
                         crispresso2_info['results']['refs'][ref_name]['plot_10d_captions'].append("Figure 10d: Log2 nucleotide frequencies for each position in the plotting window around the " + sgRNA_legend + ". The quantification window is outlined by the dotted box.")
@@ -4319,7 +4319,7 @@ def main():
                             'fig_filename_root': fig_filename_root,
                             'save_also_png': save_png,
                         }
-                        debug('Plotting conversion at {0}s around the {1}'.format(args.conversion_nuc_from, sgRNA_legend))
+                        debug('Plotting conversion at {0}s around the {1} for {21}'.format(args.conversion_nuc_from, sgRNA_legend, ref_name))
                         plot(
                             CRISPRessoPlot.plot_conversion_at_sel_nucs,
                             plot_10e_input,
@@ -4338,7 +4338,7 @@ def main():
                             'fig_filename_root': fig_filename_root,
                             'save_also_png': save_png,
                         }
-                        debug('Plotting non-reference conversion at {0}s around the {1}'.format(args.conversion_nuc_from, sgRNA_legend))
+                        debug('Plotting non-reference conversion at {0}s around the {1} for {2}'.format(args.conversion_nuc_from, sgRNA_legend, ref_name))
                         plot(
                             CRISPRessoPlot.plot_conversion_at_sel_nucs_not_include_ref,
                             plot_10f_input,
@@ -4360,7 +4360,7 @@ def main():
                             'fig_filename_root': fig_filename_root,
                             'save_also_png': save_png
                         }
-                        debug('Plotting scaled non-reference conversion at {0}s around the {1}'.format(args.conversion_nuc_from, sgRNA_legend))
+                        debug('Plotting scaled non-reference conversion at {0}s around the {1} for {2}'.format(args.conversion_nuc_from, sgRNA_legend, ref_name))
                         plot(
                             CRISPRessoPlot.plot_conversion_at_sel_nucs_not_include_ref_scaled,
                             plot_10g_input,

--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -944,22 +944,39 @@ def split_interleaved_fastq(fastq_filename, output_filename_r1, output_filename_
     return output_filename_r1, output_filename_r2
 
 
-def normalize_name(args):
-    """Normalize the name according to the inputs and clean it."""
+def normalize_name(name, fastq_r1, fastq_r2, bam_input):
+    """Normalize the name according to the inputs and clean it.
+
+    Parameters
+    ----------
+    name : str
+        The name optionally provided by the user.
+    fastq_r1 : str
+        The path to the first fastq file.
+    fastq_r2 : str
+        The path to the second fastq file.
+    bam_input : str
+        The path to the bam file.
+
+    Returns
+    -------
+    str
+        The normalized name.
+    """
     get_name_from_fasta = lambda x: os.path.basename(x).replace('.fastq', '').replace('.gz', '').replace('.fq', '')
     get_name_from_bam = lambda x: os.path.basename(x).replace('.bam', '')
 
-    if not args.name:
-        if args.fastq_r2!='':
-            return '%s_%s' % (get_name_from_fasta(args.fastq_r1), get_name_from_fasta(args.fastq_r2))
-        elif args.fastq_r1 != '':
-            return '%s' % get_name_from_fasta(args.fastq_r1)
-        elif args.bam_input != '':
-            return '%s' % get_name_from_bam(args.bam_input)
+    if not name:
+        if fastq_r2:
+            return '%s_%s' % (get_name_from_fasta(fastq_r1), get_name_from_fasta(fastq_r2))
+        elif fastq_r1:
+            return '%s' % get_name_from_fasta(fastq_r1)
+        elif bam_input != '':
+            return '%s' % get_name_from_bam(bam_input)
     else:
-        clean_name=CRISPRessoShared.slugify(args.name)
-        if args.name!= clean_name:
-            warn('The specified name %s contained invalid characters and was changed to: %s' % (args.name, clean_name))
+        clean_name=CRISPRessoShared.slugify(name)
+        if name!= clean_name:
+            warn('The specified name %s contained invalid characters and was changed to: %s' % (name, clean_name))
         return clean_name
 
 
@@ -989,7 +1006,7 @@ def main():
 
         CRISPRessoShared.set_console_log_level(logger, args.verbosity, args.debug)
 
-        OUTPUT_DIRECTORY = 'CRISPResso_on_{0}'.format(normalize_name(args))
+        OUTPUT_DIRECTORY = 'CRISPResso_on_{0}'.format(normalize_name(args.name, args.fastq_r1, args.fastq_r2, args.bam_input))
 
         if args.output_folder:
             OUTPUT_DIRECTORY = os.path.join(
@@ -1065,7 +1082,7 @@ def main():
 
         crispresso2_info['running_info']['log_filename'] = os.path.basename(log_filename)
 
-        crispresso2_info['running_info']['name'] = normalize_name(args)
+        crispresso2_info['running_info']['name'] = normalize_name(args.name, args.fastq_r1, args.fastq_r2, args.bam_input)
 
         if args.write_cleaned_report:
             cmd_copy = sys.argv[:]

--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -1019,8 +1019,7 @@ def main():
             with open(log_filename, 'w+') as outfile:
                 outfile.write('CRISPResso version %s\n[Command used]:\n%s\n\n[Execution log]:\n' %(CRISPRessoShared.__version__, crispresso_cmd_to_write))
 
-        status_handler = CRISPRessoShared.StatusHandler(_jp('status.txt'))
-        logger.addHandler(status_handler)
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('status.txt')))
 
         aln_matrix_loc = os.path.join(_ROOT, "EDNAFULL")
         CRISPRessoShared.check_file(aln_matrix_loc)
@@ -4645,7 +4644,7 @@ def main():
         if args.zip_output:
             CRISPRessoShared.zip_results(OUTPUT_DIRECTORY)
 
-        info('Analysis Complete!')
+        info('Analysis Complete!', {'percent_complete': 100})
         print(CRISPRessoShared.get_crispresso_footer())
 
         sys.exit(0)

--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -3380,7 +3380,7 @@ def main():
                 'plot_root': plot_1a_root,
                 'save_png': save_png
             }
-            info('Plotting read bar plot', {'percent_complete': 42})
+            debug('Plotting read bar plot', {'percent_complete': 42})
             plot(CRISPRessoPlot.plot_read_barplot, plot_1a_input)
             crispresso2_info['results']['general_plots']['plot_1a_root'] = os.path.basename(plot_1a_root)
             crispresso2_info['results']['general_plots']['plot_1a_caption'] = "Figure 1a: The number of reads in input fastqs, after preprocessing, and after alignment to amplicons."
@@ -3407,7 +3407,7 @@ def main():
             crispresso2_info['results']['general_plots']['plot_1c_root'] = os.path.basename(plot_1c_root)
             crispresso2_info['results']['general_plots']['plot_1c_caption'] = "Figure 1c: Alignment and editing frequency of reads as determined by the percentage and number of sequence reads showing unmodified and modified alleles."
             crispresso2_info['results']['general_plots']['plot_1c_data'] = [('Quantification of editing', os.path.basename(quant_of_editing_freq_filename))]
-            info('Plotting read class pie chart and bar plot', {'percent_complete': 44})
+            debug('Plotting read class pie chart and bar plot', {'percent_complete': 44})
             plot(CRISPRessoPlot.plot_class_piechart_and_barplot, plot_1bc_input)
             # to test, run: plot_pool.apply_async(CRISPRessoPlot.plot_class_piechart_and_barplot, kwds=plot_1bc_input).get()
 
@@ -3428,7 +3428,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
-                info('Plotting dsODN pie chart', {'percent_complete': 46})
+                debug('Plotting dsODN pie chart', {'percent_complete': 46})
                 plot(CRISPRessoPlot.plot_class_dsODN_piechart, plot_1d_input)
 
                 crispresso2_info['results']['general_plots']['plot_1d_root'] = os.path.basename(plot_root)
@@ -3464,13 +3464,7 @@ def main():
             #only show reference name in filenames if more than one reference
             ref_plot_name = refs[ref_name]['ref_plot_name']
 
-            # this is determined by the number of times the percent_complete is updated
-            num_sgRNA_steps = 5
-            num_ref_steps = 16 + (len(sgRNA_sequences) * num_sgRNA_steps)
-            ref_percent_complete_increment = ref_percent_complete_step / float(num_ref_steps)
-            percent_complete = ref_percent_complete_start + (ref_percent_complete_step * ref_index)
-            info('Begin processing amplicon {0}'.format(ref_name), {'percent_complete': percent_complete})
-
+            info('Begin processing plots for amplicon {0}'.format(ref_name), {'percent_complete': ref_percent_complete_start + (ref_percent_complete_step * ref_index)})
 
             if n_this_category < 1:
                 continue
@@ -3558,8 +3552,7 @@ def main():
                         'sgRNA_mismatches': sgRNA_mismatches,
                         'quantification_window_idxs': include_idxs_list,
                     }
-                    percent_complete += ref_percent_complete_increment
-                    info('Plotting nucleotide quilt across amplicon', {'percent_complete': percent_complete})
+                    debug('Plotting nucleotide quilt across amplicon')
                     plot(CRISPRessoPlot.plot_nucleotide_quilt, plot_2a_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_2a_root'] = os.path.basename(plot_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_2a_caption'] = "Figure 2a: Nucleotide distribution across amplicon. At each base in the reference amplicon, the percentage of each base as observed in sequencing reads is shown (A = green; C = orange; G = yellow; T = purple). Black bars show the percentage of reads for which that base was deleted. Brown bars between bases show the percentage of reads having an insertion at that position."
@@ -3605,8 +3598,7 @@ def main():
                             'sgRNA_mismatches': sgRNA_mismatches,
                             'quantification_window_idxs': new_include_idx,
                         }
-                        percent_complete += ((i + 1) / len(cut_points)) * ref_percent_complete_increment
-                        info('Plotting nucleotide distribuition around {0}'.format(sgRNA_legend), {'percent_complete': percent_complete})
+                        debug('Plotting nucleotide distribuition around {0}'.format(sgRNA_legend))
                         plot(CRISPRessoPlot.plot_nucleotide_quilt, plot_2b_input)
                         crispresso2_info['results']['refs'][ref_name]['plot_2b_roots'].append(os.path.basename(plot_root))
                         crispresso2_info['results']['refs'][ref_name]['plot_2b_captions'].append('Figure 2b: Nucleotide distribution around the ' + sgRNA_legend + '.')
@@ -3657,8 +3649,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
-                percent_complete += ref_percent_complete_increment
-                info('Plotting indel size distribution', {'percent_complete': percent_complete})
+                debug('Plotting indel size distribution')
                 plot(CRISPRessoPlot.plot_indel_size_distribution, plot_3a_input)
                 clipped_string = ""
                 if xmax < max(hlengths):
@@ -3739,8 +3730,7 @@ def main():
                     'xmax_mut': xmax_mut,
                     'save_also_png': save_png,
                 }
-                percent_complete += ref_percent_complete_increment
-                info('Plotting frequency deletions/insertions', {'percent_complete': percent_complete})
+                debug('Plotting frequency deletions/insertions')
                 plot(CRISPRessoPlot.plot_frequency_deletions_insertions, plot_3b_input)
 
                 if clipped_string != "":
@@ -3786,8 +3776,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
-                percent_complete += ref_percent_complete_increment
-                info('Plotting amplication modifications', {'percent_complete': percent_complete})
+                debug('Plotting amplication modifications')
                 plot(CRISPRessoPlot.plot_amplicon_modifications, plot_4a_input)
                 crispresso2_info['results']['refs'][ref_name]['plot_4a_root'] = os.path.basename(plot_root)
                 crispresso2_info['results']['refs'][ref_name]['plot_4a_caption'] = "Figure 4a: Combined frequency of any modification across the amplicon. Modifications outside of the quantification window are also shown."
@@ -3816,8 +3805,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
-                percent_complete += ref_percent_complete_increment
-                info('Plotting modification frequency', {'percent_complete': percent_complete})
+                debug('Plotting modification frequency')
                 plot(CRISPRessoPlot.plot_modification_frequency, plot_4b_input)
                 crispresso2_info['results']['refs'][ref_name]['plot_4b_root'] = os.path.basename(plot_root)
                 crispresso2_info['results']['refs'][ref_name]['plot_4b_caption'] = "Figure 4b: Frequency of insertions (red), deletions (purple), and substitutions (green) across the entire amplicon, including modifications outside of the quantification window."
@@ -3845,8 +3833,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
-                percent_complete += ref_percent_complete_increment
-                info('Plotting quantification window locations', {'percent_complete': percent_complete})
+                debug('Plotting quantification window locations')
                 plot(
                     CRISPRessoPlot.plot_quantification_window_locations,
                     plot_4c_input,
@@ -3876,8 +3863,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
-                percent_complete += ref_percent_complete_increment
-                info('Plotting position dependent indel', {'percent_complete': percent_complete})
+                debug('Plotting position dependent indel')
                 plot(
                     CRISPRessoPlot.plot_position_dependent_indels,
                     plot_4d_input,
@@ -3917,8 +3903,7 @@ def main():
                         crispresso2_info['results']['refs'][ref_names[0]]['plot_4f_root'] = os.path.basename(plot_root)
                         crispresso2_info['results']['refs'][ref_names[0]]['plot_4f_caption'] = "Figure 4f: Positions of modifications in HDR reads with respect to the reference sequence ("+ref_names[0]+"). Insertions: red, deletions: purple, substitutions: green. All modifications (including those outside the quantification window) are shown."
                         crispresso2_info['results']['refs'][ref_names[0]]['plot_4f_data'] = []
-                    percent_complete += ref_percent_complete_increment
-                    info('Plotting global modifications with respect to reference', {'percent_complete': percent_complete})
+                    debug('Plotting global modifications with respect to reference')
                     plot(
                         CRISPRessoPlot.plot_global_modifications_reference,
                         plot_4e_input,
@@ -3972,8 +3957,7 @@ def main():
                         'sgRNA_names': sgRNA_names,
                         'sgRNA_mismatches': sgRNA_mismatches,
                     }
-                    percent_complete += ref_percent_complete_increment
-                    info('Plotting HDR nucleotide quilt', {'percent_complete': percent_complete})
+                    debug('Plotting HDR nucleotide quilt')
                     plot(CRISPRessoPlot.plot_nucleotide_quilt, plot_4g_input)
                     crispresso2_info['results']['refs'][ref_names_for_hdr[0]]['plot_4g_root'] = os.path.basename(plot_root)
                     crispresso2_info['results']['refs'][ref_names_for_hdr[0]]['plot_4g_caption'] = "Figure 4g: Nucleotide distribution across all amplicons. At each base in the reference amplicon, the percentage of each base as observed in sequencing reads is shown (A = green; C = orange; G = yellow; T = purple). Black bars show the percentage of reads for which that base was deleted. Brown bars between bases show the percentage of reads having an insertion at that position."
@@ -4021,8 +4005,7 @@ def main():
                             'plot_root': plot_root,
                             'save_also_png': save_png,
                         }
-                        percent_complete += ref_percent_complete_increment
-                        info('Plotting frameshift analysis', {'percent_complete': percent_complete})
+                        debug('Plotting frameshift analysis')
                         plot(CRISPRessoPlot.plot_frameshift_analysis, plot_5_input)
                         crispresso2_info['results']['refs'][ref_name]['plot_5_root'] = os.path.basename(plot_root)
                         crispresso2_info['results']['refs'][ref_name]['plot_5_caption'] = "Figure 5: Frameshift analysis of coding sequence reads affected by modifications (unmodified reads are excluded from this analysis)."
@@ -4047,8 +4030,7 @@ def main():
                         'plot_root': plot_root,
                         'save_also_png': save_png,
                     }
-                    percent_complete += ref_percent_complete_increment
-                    info('Plotting frameshift frequency', {'percent_complete': percent_complete})
+                    debug('Plotting frameshift frequency')
                     plot(CRISPRessoPlot.plot_frameshift_frequency, plot_6_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_6_root'] = os.path.basename(plot_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_6_caption'] = "Figure 6: Frameshift and in-frame mutagenesis profiles indicating position affected by modification. The y axis shows the number of reads and percentage of all reads in that category (frameshifted (top) or in-frame (bottom)). %d reads with no length modifications are not shown."%hists_inframe[ref_name][0]
@@ -4076,8 +4058,7 @@ def main():
                         'plot_root': plot_root,
                         'save_also_png': save_png,
                     }
-                    percent_complete += ref_percent_complete_increment
-                    info('Plotting non-coding mutation positions', {'percent_complete': percent_complete})
+                    debug('Plotting non-coding mutation positions')
                     plot(CRISPRessoPlot.plot_non_coding_mutations, plot_7_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_7_root'] = os.path.basename(plot_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_7_caption'] = "Figure 7: Reads with insertions (red), deletions (purple), and substitutions (green) mapped to reference amplicon position exclusively in noncoding region/s (that is, without mutations affecting coding sequences). The predicted cleavage site is indicated by a vertical dashed line. Only sequence positions directly adjacent to insertions or directly affected by deletions or substitutions are plotted."
@@ -4090,8 +4071,7 @@ def main():
                         'plot_root': plot_root,
                         'save_also_png': save_png,
                     }
-                    percent_complete += ref_percent_complete_increment
-                    info('Plotting potential splice sites', {'percent_complete': percent_complete})
+                    debug('Plotting potential splice sites')
                     plot(CRISPRessoPlot.plot_potential_splice_sites, plot_8_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_8_root'] = os.path.basename(plot_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_8_caption'] = "Figure 8: Predicted impact on splice sites. Potential splice sites modified refers to reads in which the either of the two intronic positions adjacent to exon junctions are disrupted."
@@ -4116,8 +4096,7 @@ def main():
                         'save_also_png': save_png,
                         'quantification_window_idxs': include_idxs_list,
                     }
-                    percent_complete += ref_percent_complete_increment
-                    info('Plotting substitutions across reference', {'percent_complete': percent_complete})
+                    debug('Plotting substitutions across reference')
                     plot(CRISPRessoPlot.plot_subs_across_ref, plot_10a_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_10a_root'] = os.path.basename(fig_filename_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_10a_caption'] = "Figure 10a: Substitution frequencies across the amplicon."
@@ -4135,8 +4114,7 @@ def main():
                         'fig_filename_root': fig_filename_root,
                         'save_also_png': save_png
                     }
-                    percent_complete += ref_percent_complete_increment
-                    info('Plotting substitution frequency barplot', {'percent_complete': percent_complete})
+                    debug('Plotting substitution frequency barplot')
                     plot(CRISPRessoPlot.plot_sub_freqs, plot_10b_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_10b_root'] = os.path.basename(fig_filename_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_10b_caption'] = "Figure 10b: Substitution frequencies across the amplicon."
@@ -4150,8 +4128,7 @@ def main():
                         'fig_filename_root': fig_filename_root,
                         'save_also_png': save_png
                     }
-                    percent_complete += ref_percent_complete_increment
-                    info('Plotting substitution frequency barplot in quantification window', {'percent_complete': percent_complete})
+                    debug('Plotting substitution frequency barplot in quantification window')
                     plot(CRISPRessoPlot.plot_sub_freqs, plot_10c_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_10c_root'] = os.path.basename(fig_filename_root)
                     crispresso2_info['results']['refs'][ref_name]['plot_10c_caption'] = "Figure 10c: Substitution frequencies in the quantification window"
@@ -4241,8 +4218,7 @@ def main():
                         'sgRNA_mismatches': sgRNA_mismatches,
                         'annotate_wildtype_allele': args.annotate_wildtype_allele,
                     }
-                    percent_complete += ref_percent_complete_increment
-                    info('Plotting allele distribution around cut', {'percent_complete': percent_complete})
+                    debug('Plotting allele distribution around cut')
                     plot(CRISPRessoPlot.plot_alleles_table, plot_9_input)
                     crispresso2_info['results']['refs'][ref_name]['plot_9_roots'].append(os.path.basename(fig_filename_root))
                     crispresso2_info['results']['refs'][ref_name]['plot_9_captions'].append("Figure 9: Visualization of the distribution of identified alleles around the cleavage site for the " + sgRNA_legend + ". Nucleotides are indicated by unique colors (A = green; C = red; G = yellow; T = purple). Substitutions are shown in bold font. Red rectangles highlight inserted sequences. Horizontal dashed lines indicate deleted sequences. The vertical dashed line indicates the predicted cleavage site.")
@@ -4307,8 +4283,7 @@ def main():
                             'save_also_png': save_png,
                             'quantification_window_idxs': plot_quant_window_idxs,
                         }
-                        percent_complete += ref_percent_complete_increment
-                        info('Plotting log2 nucleotide frequency', {'percent_complete': percent_complete})
+                        debug('Plotting log2 nucleotide frequency')
                         plot(CRISPRessoPlot.plot_log_nuc_freqs, plot_10d_input)
                         crispresso2_info['results']['refs'][ref_name]['plot_10d_roots'].append(os.path.basename(fig_filename_root))
                         crispresso2_info['results']['refs'][ref_name]['plot_10d_captions'].append("Figure 10d: Log2 nucleotide frequencies for each position in the plotting window around the " + sgRNA_legend + ". The quantification window is outlined by the dotted box.")
@@ -4329,8 +4304,7 @@ def main():
                             'fig_filename_root': fig_filename_root,
                             'save_also_png': save_png,
                         }
-                        percent_complete += ref_percent_complete_increment
-                        info('Plotting conversion at {0}s around the {1}'.format(args.conversion_nuc_from, sgRNA_legend), {'percent_complete': percent_complete})
+                        debug('Plotting conversion at {0}s around the {1}'.format(args.conversion_nuc_from, sgRNA_legend))
                         plot(
                             CRISPRessoPlot.plot_conversion_at_sel_nucs,
                             plot_10e_input,
@@ -4349,8 +4323,7 @@ def main():
                             'fig_filename_root': fig_filename_root,
                             'save_also_png': save_png,
                         }
-                        percent_complete += ref_percent_complete_increment
-                        info('Plotting non-reference conversion at {0}s around the {1}'.format(args.conversion_nuc_from, sgRNA_legend), {'percent_complete': percent_complete})
+                        debug('Plotting non-reference conversion at {0}s around the {1}'.format(args.conversion_nuc_from, sgRNA_legend))
                         plot(
                             CRISPRessoPlot.plot_conversion_at_sel_nucs_not_include_ref,
                             plot_10f_input,
@@ -4372,8 +4345,7 @@ def main():
                             'fig_filename_root': fig_filename_root,
                             'save_also_png': save_png
                         }
-                        percent_complete += ref_percent_complete_increment
-                        info('Plotting scaled non-reference conversion at {0}s around the {1}'.format(args.conversion_nuc_from, sgRNA_legend), {'percent_complete': percent_complete})
+                        debug('Plotting scaled non-reference conversion at {0}s around the {1}'.format(args.conversion_nuc_from, sgRNA_legend))
                         plot(
                             CRISPRessoPlot.plot_conversion_at_sel_nucs_not_include_ref_scaled,
                             plot_10g_input,
@@ -4381,6 +4353,8 @@ def main():
                         crispresso2_info['results']['refs'][ref_name]['plot_10g_roots'].append(os.path.basename(fig_filename_root))
                         crispresso2_info['results']['refs'][ref_name]['plot_10g_captions'].append("Figure 10g: Non-reference base counts. For target nucleotides in the plotting window, this plot shows the number of non-reference (non-" + args.conversion_nuc_from + ") bases. The number of each target base is annotated on the reference sequence at the bottom of the plot.")
                         crispresso2_info['results']['refs'][ref_name]['plot_10g_datas'].append([('Nucleotide frequencies at ' + args.conversion_nuc_from +'s', os.path.basename(quant_window_sel_nuc_freq_filename))])
+
+            info('Done!')
 
             #END GUIDE SPECIFIC PLOTS
 
@@ -4437,7 +4411,7 @@ def main():
                         'plot_root': plot_root,
                         'save_also_png': save_png,
                     }
-                    info('Plotting global frameshift in-frame mutations pie chart', {'percent_complete': 90})
+                    debug('Plotting global frameshift in-frame mutations pie chart', {'percent_complete': 90})
                     plot(
                         CRISPRessoPlot.plot_global_frameshift_analysis,
                         plot_5a_input,
@@ -4454,7 +4428,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
-                info('Plotting global frameshift in-frame mutation profiles', {'percent_complete': 92})
+                debug('Plotting global frameshift in-frame mutation profiles', {'percent_complete': 92})
                 plot(
                     CRISPRessoPlot.plot_global_frameshift_in_frame_mutations,
                     plot_6a_input,
@@ -4476,7 +4450,7 @@ def main():
                     'plot_root': plot_root,
                     'save_also_png': save_png,
                 }
-                info('Plotting global potential splice sites pie chart', {'percent_complete': 94})
+                debug('Plotting global potential splice sites pie chart', {'percent_complete': 94})
                 plot(CRISPRessoPlot.plot_impact_on_splice_sites, plot_8a_input)
                 crispresso2_info['results']['general_plots']['plot_8a_root'] = os.path.basename(plot_root)
                 crispresso2_info['results']['general_plots']['plot_8a_caption'] = "Figure 8a: Predicted impact on splice sites for all reads. Potential splice sites modified refers to reads in which the either of the two intronic positions adjacent to exon junctions are disrupted."

--- a/CRISPResso2/CRISPRessoCompareCORE.py
+++ b/CRISPResso2/CRISPRessoCompareCORE.py
@@ -14,14 +14,11 @@ from CRISPResso2 import CRISPRessoPlot
 from CRISPResso2 import CRISPRessoReport
 
 import logging
-logging.basicConfig(
-                     format='%(levelname)-5s @ %(asctime)s:\n\t %(message)s \n',
-                     datefmt='%a, %d %b %Y %H:%M:%S',
-                     stream=sys.stderr,
-                     filemode="w"
-                     )
+
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(CRISPRessoShared.LogStreamHandler())
+
 error   = logger.critical
 warn    = logger.warning
 debug   = logger.debug

--- a/CRISPResso2/CRISPRessoCompareCORE.py
+++ b/CRISPResso2/CRISPRessoCompareCORE.py
@@ -61,15 +61,15 @@ import scipy.stats as stats
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
-def normalize_name(args):
+def normalize_name(name, output_folder_1, output_folder_2):
     get_name_from_folder = lambda x: os.path.basename(os.path.abspath(x)).replace('CRISPResso_on_', '')
-    if not args.name:
+    if not name:
         return '{0}_VS_{1}'.format(
-            get_name_from_folder(args.crispresso_output_folder_1),
-            get_name_from_folder(args.crispresso_output_folder_2),
+            get_name_from_folder(output_folder_1),
+            get_name_from_folder(output_folder_2),
         )
     else:
-        return args.name
+        return name
 
 
 def main():
@@ -135,10 +135,12 @@ def main():
         if sample_1_name == sample_2_name:
             sample_2_name += '_2'
 
-        OUTPUT_DIRECTORY = 'CRISPRessoCompare_on_{0}'.format(normalize_name(args))
+        OUTPUT_DIRECTORY = 'CRISPRessoCompare_on_{0}'.format(normalize_name(
+            args.name, args.crispresso_output_folder_1, args.crispresso_output_folder_2,
+        ))
 
         if args.output_folder:
-            OUTPUT_DIRECTORY=os.path.join(os.path.abspath(args.output_folder), OUTPUT_DIRECTORY)
+            OUTPUT_DIRECTORY = os.path.join(os.path.abspath(args.output_folder), OUTPUT_DIRECTORY)
 
         _jp = lambda filename: os.path.join(OUTPUT_DIRECTORY, filename) #handy function to put a file in the output directory
         log_filename = _jp('CRISPRessoCompare_RUNNING_LOG.txt')

--- a/CRISPResso2/CRISPRessoCompareCORE.py
+++ b/CRISPResso2/CRISPRessoCompareCORE.py
@@ -103,6 +103,9 @@ def main():
         parser.add_argument('--debug', help='Show debug messages', action='store_true')
 
         args = parser.parse_args()
+
+        CRISPRessoShared.set_console_log_level(logger, args.verbosity, args.debug)
+
         debug_flag = args.debug
 
         if args.zip_output and not args.place_report_in_output_folder:

--- a/CRISPResso2/CRISPRessoCompareCORE.py
+++ b/CRISPResso2/CRISPRessoCompareCORE.py
@@ -101,6 +101,7 @@ def main():
         parser.add_argument('--place_report_in_output_folder',  help='If true, report will be written inside the CRISPResso output folder. By default, the report will be written one directory up from the report output.', action='store_true')
         parser.add_argument('--zip_output', help="If set, the output will be placed in a zip folder.", action='store_true')
         parser.add_argument('--debug', help='Show debug messages', action='store_true')
+        parser.add_argument('-v', '--verbosity', type=int, help='Verbosity level of output to the console (1-4)', default=3)
 
         args = parser.parse_args()
 

--- a/CRISPResso2/CRISPRessoCompareCORE.py
+++ b/CRISPResso2/CRISPRessoCompareCORE.py
@@ -64,6 +64,16 @@ import scipy.stats as stats
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
+def normalize_name(args):
+    get_name_from_folder = lambda x: os.path.basename(os.path.abspath(x)).replace('CRISPResso_on_', '')
+    if not args.name:
+        return '{0}_VS_{1}'.format(
+            get_name_from_folder(args.crispresso_output_folder_1),
+            get_name_from_folder(args.crispresso_output_folder_2),
+        )
+    else:
+        return args.name
+
 
 def main():
     try:
@@ -124,35 +134,27 @@ def main():
         if sample_1_name == sample_2_name:
             sample_2_name += '_2'
 
-        get_name_from_folder=lambda x: os.path.basename(os.path.abspath(x)).replace('CRISPResso_on_', '')
-
-        if not args.name:
-                 database_id='%s_VS_%s' % (get_name_from_folder(args.crispresso_output_folder_1), get_name_from_folder(args.crispresso_output_folder_2))
-        else:
-                 database_id=args.name
-
-
-        OUTPUT_DIRECTORY='CRISPRessoCompare_on_%s' % database_id
+        OUTPUT_DIRECTORY = 'CRISPRessoCompare_on_{0}'.format(normalize_name(args))
 
         if args.output_folder:
-                 OUTPUT_DIRECTORY=os.path.join(os.path.abspath(args.output_folder), OUTPUT_DIRECTORY)
+            OUTPUT_DIRECTORY=os.path.join(os.path.abspath(args.output_folder), OUTPUT_DIRECTORY)
 
-        _jp=lambda filename: os.path.join(OUTPUT_DIRECTORY, filename) #handy function to put a file in the output directory
-        log_filename=_jp('CRISPRessoCompare_RUNNING_LOG.txt')
-
+        _jp = lambda filename: os.path.join(OUTPUT_DIRECTORY, filename) #handy function to put a file in the output directory
+        log_filename = _jp('CRISPRessoCompare_RUNNING_LOG.txt')
 
         try:
-                 info('Creating Folder %s' % OUTPUT_DIRECTORY)
-                 os.makedirs(OUTPUT_DIRECTORY)
-                 info('Done!')
+            info('Creating Folder %s' % OUTPUT_DIRECTORY)
+            os.makedirs(OUTPUT_DIRECTORY)
+            info('Done!')
         except:
-                 warn('Folder %s already exists.' % OUTPUT_DIRECTORY)
+            warn('Folder %s already exists.' % OUTPUT_DIRECTORY)
 
-        log_filename=_jp('CRISPRessoCompare_RUNNING_LOG.txt')
+        log_filename = _jp('CRISPRessoCompare_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('status.txt')))
 
         with open(log_filename, 'w+') as outfile:
-                  outfile.write('[Command used]:\nCRISPRessoCompare %s\n\n[Execution log]:\n' % ' '.join(sys.argv))
+            outfile.write('[Command used]:\nCRISPRessoCompare %s\n\n[Execution log]:\n' % ' '.join(sys.argv))
 
         crispresso2Compare_info_file = os.path.join(OUTPUT_DIRECTORY, 'CRISPResso2Compare_info.json')
         crispresso2_info = {'running_info': {}, 'results': {'alignment_stats': {}, 'general_plots': {}}} #keep track of all information for this run to be pickled and saved at the end of the run
@@ -439,7 +441,7 @@ def main():
         if args.zip_output:
             CRISPRessoShared.zip_results(OUTPUT_DIRECTORY)
 
-        info('Analysis Complete!')
+        info('Analysis Complete!', {'percent_complete': 100})
         print(CRISPRessoShared.get_crispresso_footer())
         sys.exit(0)
 

--- a/CRISPResso2/CRISPRessoCompareCORE.py
+++ b/CRISPResso2/CRISPRessoCompareCORE.py
@@ -151,7 +151,7 @@ def main():
 
         log_filename = _jp('CRISPRessoCompare_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPResso_status.txt')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPRessoCompare_status.txt')))
 
         with open(log_filename, 'w+') as outfile:
             outfile.write('[Command used]:\nCRISPRessoCompare %s\n\n[Execution log]:\n' % ' '.join(sys.argv))

--- a/CRISPResso2/CRISPRessoCompareCORE.py
+++ b/CRISPResso2/CRISPRessoCompareCORE.py
@@ -151,7 +151,7 @@ def main():
 
         log_filename = _jp('CRISPRessoCompare_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('status.txt')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPResso_status.txt')))
 
         with open(log_filename, 'w+') as outfile:
             outfile.write('[Command used]:\nCRISPRessoCompare %s\n\n[Execution log]:\n' % ' '.join(sys.argv))

--- a/CRISPResso2/CRISPRessoCompareCORE.py
+++ b/CRISPResso2/CRISPRessoCompareCORE.py
@@ -143,7 +143,7 @@ def main():
         log_filename = _jp('CRISPRessoCompare_RUNNING_LOG.txt')
 
         try:
-            info('Creating Folder %s' % OUTPUT_DIRECTORY)
+            info('Creating Folder %s' % OUTPUT_DIRECTORY, {'percent_complete': 0})
             os.makedirs(OUTPUT_DIRECTORY)
             info('Done!')
         except:
@@ -182,7 +182,11 @@ def main():
 
         sig_counts = {}  # number of bp significantly modified (bonferonni corrected fisher pvalue)
         sig_counts_quant_window = {}
+        percent_complete_start, percent_complete_end = 10, 90
+        percent_complete_step = (percent_complete_end - percent_complete_start) / len(amplicon_names_in_both)
         for amplicon_name in amplicon_names_in_both:
+            percent_complete = percent_complete_start + percent_complete_step * amplicon_names_in_both.index(amplicon_name)
+            info('Loading data for amplicon %s' % amplicon_name, {'percent_complete': percent_complete})
             profile_1=parse_profile(amplicon_info_1[amplicon_name]['quantification_file'])
             profile_2=parse_profile(amplicon_info_2[amplicon_name]['quantification_file'])
 
@@ -411,6 +415,7 @@ def main():
                         'The proportion and number of reads is shown for each sample on the right, with the values for ' + sample_1_name + ' followed by the values for ' + sample_2_name +'. Alleles are sorted for enrichment in ' + sample_2_name+'.'
                         crispresso2_info['results']['general_plots']['summary_plot_datas'][plot_name] = [('Allele comparison table', os.path.basename(allele_comparison_file))]
 
+        debug('Calculating significant base counts...', {'percent_complete': 95})
         sig_counts_filename = _jp('CRISPRessoCompare_significant_base_counts.txt')
         with open(sig_counts_filename, 'w') as fout:
             fout.write('Amplicon\tModification\tsig_base_count\tsig_base_count_quant_window\n')

--- a/CRISPResso2/CRISPRessoMetaCORE.py
+++ b/CRISPResso2/CRISPRessoMetaCORE.py
@@ -257,7 +257,7 @@ def main():
         crispresso2_info['meta_names_arr'] = meta_names_arr
         crispresso2_info['meta_input_names'] = meta_input_names
 
-        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, args.n_processes, 'meta', args.skip_failed, start_end_percent=(10, 90))
+        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, args.n_processes, 'meta', args.skip_failed, start_end_percent=(10, 90))
 
         run_datas = [] #crispresso2 info from each row
 

--- a/CRISPResso2/CRISPRessoMetaCORE.py
+++ b/CRISPResso2/CRISPRessoMetaCORE.py
@@ -256,7 +256,7 @@ def main():
         crispresso2_info['meta_names_arr'] = meta_names_arr
         crispresso2_info['meta_input_names'] = meta_input_names
 
-        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, args.n_processes, 'meta', args.skip_failed)
+        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, args.n_processes, 'meta', args.skip_failed)
 
         run_datas = [] #crispresso2 info from each row
 

--- a/CRISPResso2/CRISPRessoMetaCORE.py
+++ b/CRISPResso2/CRISPRessoMetaCORE.py
@@ -96,6 +96,8 @@ def main():
 
         args = parser.parse_args()
 
+        CRISPRessoShared.set_console_log_level(logger, args.verbosity, args.debug)
+
         debug_flag = args.debug
 
         crispresso_options = CRISPRessoShared.get_crispresso_options()

--- a/CRISPResso2/CRISPRessoMetaCORE.py
+++ b/CRISPResso2/CRISPRessoMetaCORE.py
@@ -222,13 +222,14 @@ def main():
         _jp=lambda filename: os.path.join(OUTPUT_DIRECTORY, filename) #handy function to put a file in the output directory
 
         try:
-            info('Creating Folder %s' % OUTPUT_DIRECTORY)
+            info('Creating Folder %s' % OUTPUT_DIRECTORY, {'percent_complete': 0})
             os.makedirs(OUTPUT_DIRECTORY)
         except:
             warn('Folder %s already exists.' % OUTPUT_DIRECTORY)
 
         log_filename=_jp('CRISPRessoMeta_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPRessoMeta_status.txt')))
 
         with open(log_filename, 'w+') as outfile:
             outfile.write('[Command used]:\n%s\n\n[Execution log]:\n' % ' '.join(sys.argv))
@@ -256,7 +257,7 @@ def main():
         crispresso2_info['meta_names_arr'] = meta_names_arr
         crispresso2_info['meta_input_names'] = meta_input_names
 
-        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, args.n_processes, 'meta', args.skip_failed)
+        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, args.n_processes, 'meta', args.skip_failed, start_end_percent=(10, 90))
 
         run_datas = [] #crispresso2 info from each row
 
@@ -360,7 +361,7 @@ def main():
         CRISPRessoShared.write_crispresso_info(
             crispresso2Meta_info_file, crispresso2_info,
         )
-        info('Analysis Complete!')
+        info('Analysis Complete!', {'percent_complete': 100})
         print(CRISPRessoShared.get_crispresso_footer())
         sys.exit(0)
 

--- a/CRISPResso2/CRISPRessoMetaCORE.py
+++ b/CRISPResso2/CRISPRessoMetaCORE.py
@@ -19,14 +19,9 @@ from CRISPResso2 import CRISPRessoReport
 
 
 import logging
-logging.basicConfig(
-                     format='%(levelname)-5s @ %(asctime)s:\n\t %(message)s \n',
-                     datefmt='%a, %d %b %Y %H:%M:%S',
-                     stream=sys.stderr,
-                     filemode="w"
-                     )
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(CRISPRessoShared.LogStreamHandler())
 
 error   = logger.critical
 warn    = logger.warning

--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -326,7 +326,7 @@ def main():
 
         log_filename = _jp('CRISPRessoPooled_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPResso_status.txt')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPRessoPooled_status.txt')))
 
         if args.zip_output and not args.place_report_in_output_folder:
             logger.warn('Invalid arguement combination: If zip_output is True then place_report_in_output_folder must also be True. Setting place_report_in_output_folder to True.')

--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -841,7 +841,7 @@ def main():
                 else:
                     warn('Skipping amplicon [%s] because no reads align to it\n'% idx)
 
-            CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes_for_pooled, 'amplicon', args.skip_failed, start_end_percent=(16, 80))
+            CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, n_processes_for_pooled, 'amplicon', args.skip_failed, start_end_percent=(16, 80))
 
             df_template['n_reads']=n_reads_aligned_amplicons
             df_template['n_reads_aligned_%']=df_template['n_reads']/float(N_READS_ALIGNED)*100
@@ -1214,7 +1214,7 @@ def main():
                         n_reads_aligned_genome.append(0)
                         warn("The amplicon %s doesn't have any reads mapped to it!\n Please check your amplicon sequence." %  idx)
 
-                CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes_for_pooled, 'amplicon', args.skip_failed, start_end_percent=(15, 85))
+                CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, n_processes_for_pooled, 'amplicon', args.skip_failed, start_end_percent=(15, 85))
 
                 crispresso2_info['running_info']['finished_steps']['crispresso_amplicons_and_genome'] = (n_reads_aligned_genome, fastq_region_filenames, files_to_match)
                 CRISPRessoShared.write_crispresso_info(
@@ -1322,7 +1322,7 @@ def main():
                         crispresso_cmds.append(crispresso_cmd)
                     else:
                         info('Skipping region: %s-%d-%d , not enough reads (%d)' %(row.chr_id, row.bpstart, row.bpend, row.n_reads))
-                CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes_for_pooled, 'region', args.skip_failed, start_end_percent=(15, 85))
+                CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, n_processes_for_pooled, 'region', args.skip_failed, start_end_percent=(15, 85))
 
                 crispresso2_info['running_info']['finished_steps']['crispresso_genome_only'] = True
                 CRISPRessoShared.write_crispresso_info(

--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -23,14 +23,11 @@ from CRISPResso2 import CRISPRessoPlot
 import traceback
 
 import logging
-logging.basicConfig(
-                     format='%(levelname)-5s @ %(asctime)s:\n\t %(message)s \n',
-                     datefmt='%a, %d %b %Y %H:%M:%S',
-                     stream=sys.stderr,
-                     filemode="w"
-                     )
+
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(CRISPRessoShared.LogStreamHandler())
+
 error   = logger.critical
 warn    = logger.warning
 debug   = logger.debug

--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -301,6 +301,8 @@ def main():
 
         args = parser.parse_args()
 
+        CRISPRessoShared.set_console_log_level(logger, args.verbosity, args.debug)
+
         crispresso_options = CRISPRessoShared.get_crispresso_options()
         options_to_ignore = {'fastq_r1', 'fastq_r2', 'amplicon_seq', 'amplicon_name', 'output_folder', 'name', 'zip_output'}
         crispresso_options_for_pooled = list(crispresso_options-options_to_ignore)

--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -1605,7 +1605,7 @@ def main():
         if args.zip_output:
             CRISPRessoShared.zip_results(OUTPUT_DIRECTORY)
 
-        info('All Done!')
+        info('All Done!', {'percent_complete': 100})
         print(CRISPRessoShared.get_crispresso_footer())
         sys.exit(0)
 

--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -823,7 +823,7 @@ def main():
                 else:
                     warn('Skipping amplicon [%s] because no reads align to it\n'% idx)
 
-            CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, n_processes_for_pooled, 'amplicon', args.skip_failed)
+            CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes_for_pooled, 'amplicon', args.skip_failed)
 
             df_template['n_reads']=n_reads_aligned_amplicons
             df_template['n_reads_aligned_%']=df_template['n_reads']/float(N_READS_ALIGNED)*100
@@ -1194,7 +1194,7 @@ def main():
                         n_reads_aligned_genome.append(0)
                         warn("The amplicon %s doesn't have any reads mapped to it!\n Please check your amplicon sequence." %  idx)
 
-                CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, n_processes_for_pooled, 'amplicon', args.skip_failed)
+                CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes_for_pooled, 'amplicon', args.skip_failed)
 
                 crispresso2_info['running_info']['finished_steps']['crispresso_amplicons_and_genome'] = (n_reads_aligned_genome, fastq_region_filenames, files_to_match)
                 CRISPRessoShared.write_crispresso_info(
@@ -1302,7 +1302,7 @@ def main():
                         crispresso_cmds.append(crispresso_cmd)
                     else:
                         info('Skipping region: %s-%d-%d , not enough reads (%d)' %(row.chr_id, row.bpstart, row.bpend, row.n_reads))
-                CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, n_processes_for_pooled, 'region', args.skip_failed)
+                CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes_for_pooled, 'region', args.skip_failed)
 
                 crispresso2_info['running_info']['finished_steps']['crispresso_genome_only'] = True
                 CRISPRessoShared.write_crispresso_info(

--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -935,7 +935,9 @@ def main():
 
         # align reads to the genome in an unbiased way
         if RUNNING_MODE=='ONLY_GENOME' or RUNNING_MODE=='AMPLICONS_AND_GENOME':
-            bam_filename_genome = _jp('%s_GENOME_ALIGNED.bam' % database_id)
+            bam_filename_genome = _jp('{0}_GENOME_ALIGNED.bam'.format(normalize_name(
+                args.name, args.fastq_r1, args.fastq_r2, args.aligned_pooled_bam,
+            )))
             # if input bam is provided, don't align reads to the genome and use that bam
             if args.aligned_pooled_bam is not None:
                 bam_filename_genome = args.aligned_pooled_bam

--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -326,7 +326,7 @@ def main():
 
         log_filename = _jp('CRISPRessoPooled_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('status.txt')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPResso_status.txt')))
 
         if args.zip_output and not args.place_report_in_output_folder:
             logger.warn('Invalid arguement combination: If zip_output is True then place_report_in_output_folder must also be True. Setting place_report_in_output_folder to True.')

--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -194,24 +194,41 @@ def find_overlapping_genes(row, df_genes):
     return row
 
 
-def normalize_name(args):
-    """Normalize the name according to the inputs and clean it."""
-    get_name_from_fasta = lambda x: os.path.basename(x).replace('.fastq', '').replace('.gz', '').replace('.fq', '')
+def normalize_name(name, fastq_r1, fastq_r2, aligned_pooled_bam):
+    """Normalize the name according to the inputs and clean it.
+
+    Parameters
+    ----------
+    name : str
+        The name optionally given by the user.
+    fastq_r1 : str
+        The path to the first fastq file.
+    fastq_r2 : str
+        The path to the second fastq file.
+    aligned_pooled_bam : str
+        The path to the aligned bam file.
+
+    Returns
+    -------
+    str
+        The normalized name.
+    """
+    get_name_from_fastq = lambda x: os.path.basename(x).replace('.fastq', '').replace('.gz', '').replace('.fq', '')
     get_name_from_bam = lambda x: os.path.basename(x).replace('.bam', '')
 
-    if not args.name:
-        if args.aligned_pooled_bam is not None:
-            return get_name_from_bam(args.aligned_pooled_bam)
-        elif args.fastq_r2 != '':
-            return '%s_%s' % (get_name_from_fasta(args.fastq_r1), get_name_from_fasta(args.fastq_r2))
+    if not name:
+        if aligned_pooled_bam is not None:
+            return get_name_from_bam(aligned_pooled_bam)
+        elif fastq_r2:
+            return '%s_%s' % (get_name_from_fastq(fastq_r1), get_name_from_fastq(fastq_r2))
         else:
-            return '%s' % get_name_from_fasta(args.fastq_r1)
+            return '%s' % get_name_from_fastq(fastq_r1)
     else:
-        clean_name = CRISPRessoShared.slugify(args.name)
-        if args.name != clean_name:
+        clean_name = CRISPRessoShared.slugify(name)
+        if name != clean_name:
             warn(
                 'The specified name {0} contained invalid characters and was changed to: {1}'.format(
-                    args.name, clean_name,
+                    name, clean_name,
                 ),
             )
         return clean_name
@@ -309,7 +326,7 @@ def main():
 
         files_to_remove = []
 
-        OUTPUT_DIRECTORY = 'CRISPRessoPooled_on_{0}'.format(normalize_name(args))
+        OUTPUT_DIRECTORY = 'CRISPRessoPooled_on_{0}'.format(normalize_name(args.name, args.fastq_r1, args.fastq_r2, args.aligned_pooled_bam))
 
         if args.output_folder:
             OUTPUT_DIRECTORY = os.path.join(os.path.abspath(args.output_folder), OUTPUT_DIRECTORY)

--- a/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
+++ b/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
@@ -159,6 +159,7 @@ increase the memory required to run CRISPResso. Can be set to 'max'.
             action='store_true',
         )
         parser.add_argument('--zip_output', help="If set, the output will be placed in a zip folder.", action='store_true')
+        parser.add_argument('-v', '--verbosity', type=int, help='Verbosity level of output to the console (1-4)', default=3)
 
         args = parser.parse_args()
 

--- a/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
+++ b/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
@@ -161,6 +161,9 @@ increase the memory required to run CRISPResso. Can be set to 'max'.
         parser.add_argument('--zip_output', help="If set, the output will be placed in a zip folder.", action='store_true')
 
         args = parser.parse_args()
+
+        CRISPRessoShared.set_console_log_level(logger, args.verbosity, args.debug)
+
         debug_flag = args.debug
 
         crispresso_compare_options = [

--- a/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
+++ b/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
@@ -16,14 +16,11 @@ import traceback
 
 
 import logging
-logging.basicConfig(
-    format='%(levelname)-5s @ %(asctime)s:\n\t %(message)s \n',
-    datefmt='%a, %d %b %Y %H:%M:%S',
-    stream=sys.stderr,
-    filemode="w"
-)
+
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(CRISPRessoShared.LogStreamHandler())
+
 error   = logger.critical
 warn    = logger.warning
 debug   = logger.debug

--- a/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
+++ b/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
@@ -327,7 +327,7 @@ increase the memory required to run CRISPResso. Can be set to 'max'.
                 processed_region_html_files[idx] = this_sub_html_file
                 processed_region_folder_names[idx] = compare_output_name
 
-        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes, 'Comparison', start_end_percent=(10, 90))
+        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, n_processes, 'Comparison', start_end_percent=(10, 90))
         crispresso2_info['results']['processed_regions'] = processed_regions
         crispresso2_info['results']['processed_region_folder_names'] = processed_region_folder_names
 

--- a/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
+++ b/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
@@ -230,7 +230,7 @@ increase the memory required to run CRISPResso. Can be set to 'max'.
 
         log_filename = _jp('CRISPRessoPooledWGSCompare_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('status.txt')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPResso_status.txt')))
 
         with open(log_filename, 'w+') as outfile:
             outfile.write(

--- a/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
+++ b/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
@@ -230,6 +230,7 @@ increase the memory required to run CRISPResso. Can be set to 'max'.
 
         log_filename = _jp('CRISPRessoPooledWGSCompare_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('status.txt')))
 
         with open(log_filename, 'w+') as outfile:
             outfile.write(
@@ -374,7 +375,7 @@ increase the memory required to run CRISPResso. Can be set to 'max'.
         if args.zip_output:
             CRISPRessoShared.zip_results(OUTPUT_DIRECTORY)
 
-        info('All Done!')
+        info('All Done!', {'percent_complete': 100})
         print(CRISPRessoShared.get_crispresso_footer())
         sys.exit(0)
 

--- a/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
+++ b/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
@@ -222,7 +222,7 @@ increase the memory required to run CRISPResso. Can be set to 'max'.
         log_filename = _jp('CRISPRessoPooledWGSCompare_RUNNING_LOG.txt')
 
         try:
-            info('Creating Folder %s' % OUTPUT_DIRECTORY)
+            info('Creating Folder %s' % OUTPUT_DIRECTORY, {'percent_complete': 0})
             os.makedirs(OUTPUT_DIRECTORY)
             info('Done!')
         except:
@@ -265,7 +265,7 @@ increase the memory required to run CRISPResso. Can be set to 'max'.
             rsuffix='_{0}'.format(sample_2_name),
         )
 
-        print('looking for ' + '({0}-{1})_Unmodified%'.format(sample_1_name, sample_2_name))
+        debug('looking for ' + '({0}-{1})_Unmodified%'.format(sample_1_name, sample_2_name))
         df_comp[
             '({0}-{1})_Unmodified%'.format(sample_1_name, sample_2_name)
         ] = df_comp['Unmodified%_{0}'.format(sample_1_name)] - df_comp[
@@ -326,7 +326,7 @@ increase the memory required to run CRISPResso. Can be set to 'max'.
                 processed_region_html_files[idx] = this_sub_html_file
                 processed_region_folder_names[idx] = compare_output_name
 
-        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes, 'Comparison')
+        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes, 'Comparison', start_end_percent=(10, 90))
         crispresso2_info['results']['processed_regions'] = processed_regions
         crispresso2_info['results']['processed_region_folder_names'] = processed_region_folder_names
 

--- a/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
+++ b/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
@@ -230,7 +230,7 @@ increase the memory required to run CRISPResso. Can be set to 'max'.
 
         log_filename = _jp('CRISPRessoPooledWGSCompare_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPResso_status.txt')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPRessoPooledWGSCompare_status.txt')))
 
         with open(log_filename, 'w+') as outfile:
             outfile.write(

--- a/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
+++ b/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
@@ -326,9 +326,7 @@ increase the memory required to run CRISPResso. Can be set to 'max'.
                 processed_region_html_files[idx] = this_sub_html_file
                 processed_region_folder_names[idx] = compare_output_name
 
-        CRISPRessoMultiProcessing.run_crispresso_cmds(
-            crispresso_cmds, n_processes, 'Comparison',
-        )
+        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes, 'Comparison')
         crispresso2_info['results']['processed_regions'] = processed_regions
         crispresso2_info['results']['processed_region_folder_names'] = processed_region_folder_names
 

--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -73,6 +73,9 @@ class StatusFormatter(logging.Formatter):
         record.percent_complete = ''
         if record.args and 'percent_complete' in record.args:
             record.percent_complete = '{0:.2f}% '.format(record.args['percent_complete'])
+            self.last_percent_complete = record.percent_complete
+        elif hasattr(self, 'last_percent_complete'): # if we don't have a percent complete, use the last one
+            record.percent_complete = self.last_percent_complete
         return super().format(record)
 
 

--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -175,7 +175,7 @@ def getCRISPRessoArgParser(parserTitle="CRISPResso Parameters", requiredParams={
                         default='')
     parser.add_argument('-o', '--output_folder', help='Output folder to use for the analysis (default: current folder)',
                         default='')
-    parser.add_argument('-v', '--verbosity', type=int, help='Verbosity level of output to the console (1-4)', default=3)
+    parser.add_argument('-v', '--verbosity', type=int, help='Verbosity level of output to the console (1-4), 4 is the most verbose', default=3)
 
     ## read preprocessing params
     parser.add_argument('--split_interleaved_input', '--split_paired_end',

--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -72,8 +72,7 @@ class StatusFormatter(Formatter):
     def format(self, record):
         record.percent_complete = ''
         if record.args and 'percent_complete' in record.args:
-            print(record.args)
-            record.percent_complete = '{0}% complete '.format(record.args['percent_complete'])
+            record.percent_complete = '{0:.2f}% '.format(record.args['percent_complete'])
         return super().format(record)
 
 

--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -18,6 +18,7 @@ import shutil
 import signal
 import subprocess as sb
 import unicodedata
+from logging import FileHandler, StreamHandler
 
 from CRISPResso2 import CRISPResso2Align
 from CRISPResso2 import CRISPRessoCOREResources
@@ -66,6 +67,19 @@ class InstallationException(Exception):
     pass
 
 #########################################
+
+class StatusHandler(FileHandler):
+    def __init__(self, filename):
+        super().__init__(filename, 'w')
+
+    def emit(self, record):
+        """Overwrite the existing file and write the new log."""
+        if self.stream is None:  # log file is empty
+            self.stream = self._open()
+        else:  # log file is not empty, overwrite
+            self.stream.seek(0)
+        StreamHandler.emit(self, record)
+        self.stream.truncate()
 
 
 def getCRISPRessoArgParser(parserTitle="CRISPResso Parameters", requiredParams={}):

--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -18,7 +18,7 @@ import shutil
 import signal
 import subprocess as sb
 import unicodedata
-from logging import FileHandler, Formatter, StreamHandler
+from logging import FileHandler, Formatter, INFO, StreamHandler
 
 from CRISPResso2 import CRISPResso2Align
 from CRISPResso2 import CRISPRessoCOREResources
@@ -89,6 +89,17 @@ class StatusHandler(FileHandler):
             self.stream.seek(0)
         StreamHandler.emit(self, record)
         self.stream.truncate()
+
+
+class LogStreamHandler(StreamHandler):
+    def __init__(self, stream=None):
+        super().__init__(stream)
+        self.setFormatter(Formatter(
+            '%(levelname)-5s @ %(asctime)s:\n\t %(message)s \n',
+            datefmt='%a, %d %b %Y %H:%M:%S',
+        ))
+        self.setLevel(INFO)
+        self.name = 'LogStreamHandler'
 
 
 def getCRISPRessoArgParser(parserTitle="CRISPResso Parameters", requiredParams={}):

--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -18,7 +18,7 @@ import shutil
 import signal
 import subprocess as sb
 import unicodedata
-from logging import FileHandler, StreamHandler
+from logging import FileHandler, Formatter, StreamHandler
 
 from CRISPResso2 import CRISPResso2Align
 from CRISPResso2 import CRISPRessoCOREResources
@@ -68,9 +68,19 @@ class InstallationException(Exception):
 
 #########################################
 
+class StatusFormatter(Formatter):
+    def format(self, record):
+        record.percent_complete = ''
+        if record.args and 'percent_complete' in record.args:
+            print(record.args)
+            record.percent_complete = '{0}% complete '.format(record.args['percent_complete'])
+        return super().format(record)
+
+
 class StatusHandler(FileHandler):
     def __init__(self, filename):
         super().__init__(filename, 'w')
+        self.setFormatter(StatusFormatter('%(percent_complete)s%(message)s'))
 
     def emit(self, record):
         """Overwrite the existing file and write the new log."""

--- a/CRISPResso2/CRISPRessoWGSCORE.py
+++ b/CRISPResso2/CRISPRessoWGSCORE.py
@@ -608,7 +608,7 @@ def main():
             else:
                 info('\nThe region [%s] has too few reads mapped to it (%d)! Not running CRISPResso!' % (idx, row['n_reads']))
 
-        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, n_processes_for_wgs, 'region', args.skip_failed)
+        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes_for_wgs, 'region', args.skip_failed)
 
         quantification_summary=[]
         all_region_names = []

--- a/CRISPResso2/CRISPRessoWGSCORE.py
+++ b/CRISPResso2/CRISPRessoWGSCORE.py
@@ -315,6 +315,8 @@ def main():
 
         args = parser.parse_args()
 
+        CRISPRessoShared.set_console_log_level(logger, args.verbosity, args.debug)
+
         crispresso_options = CRISPRessoShared.get_crispresso_options()
         options_to_ignore = {'fastq_r1', 'fastq_r2', 'amplicon_seq', 'amplicon_name', 'output_folder', 'name', 'zip_output'}
         crispresso_options_for_wgs = list(crispresso_options-options_to_ignore)

--- a/CRISPResso2/CRISPRessoWGSCORE.py
+++ b/CRISPResso2/CRISPRessoWGSCORE.py
@@ -622,7 +622,7 @@ def main():
             else:
                 info('\nThe region [%s] has too few reads mapped to it (%d)! Not running CRISPResso!' % (idx, row['n_reads']))
 
-        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, logger, n_processes_for_wgs, 'region', args.skip_failed)
+        CRISPRessoMultiProcessing.run_crispresso_cmds(crispresso_cmds, n_processes_for_wgs, 'region', args.skip_failed)
 
         quantification_summary=[]
         all_region_names = []

--- a/CRISPResso2/CRISPRessoWGSCORE.py
+++ b/CRISPResso2/CRISPRessoWGSCORE.py
@@ -247,17 +247,31 @@ def extract_reads_chunk(df):
     return new_df
 
 
-def normalize_name(args):
+def normalize_name(name, bam_file):
+    """Normalize the name of the bam file such thta it doesn't include invalid characters.
+
+    Parameters
+    ----------
+    name : str
+        The name optionally provided by the user.
+    bam_file : str
+        The name of the bam file.
+
+    Returns
+    -------
+    str
+        The normalized name.
+    """
     get_name_from_bam = lambda  x: os.path.basename(x).replace('.bam', '')
 
-    if not args.name:
-        return get_name_from_bam(args.bam_file)
+    if not name:
+        return get_name_from_bam(bam_file)
     else:
-        clean_name = CRISPRessoShared.slugify(args.name)
-        if args.name != clean_name:
+        clean_name = CRISPRessoShared.slugify(name)
+        if name != clean_name:
             warn(
                 'The specified name {0} contained invalid characters and was changed to: {1}'.format(
-                    args.name, clean_name,
+                    name, clean_name,
                 ),
             )
         return clean_name
@@ -321,7 +335,7 @@ def main():
         options_to_ignore = {'fastq_r1', 'fastq_r2', 'amplicon_seq', 'amplicon_name', 'output_folder', 'name', 'zip_output'}
         crispresso_options_for_wgs = list(crispresso_options-options_to_ignore)
 
-        OUTPUT_DIRECTORY='CRISPRessoWGS_on_%s' % normalize_name(args)
+        OUTPUT_DIRECTORY='CRISPRessoWGS_on_%s' % normalize_name(args.name, args.bam_file)
         if args.output_folder:
             OUTPUT_DIRECTORY=os.path.join(os.path.abspath(args.output_folder), OUTPUT_DIRECTORY)
 

--- a/CRISPResso2/CRISPRessoWGSCORE.py
+++ b/CRISPResso2/CRISPRessoWGSCORE.py
@@ -334,7 +334,7 @@ def main():
         except:
             warn('Folder %s already exists.' % OUTPUT_DIRECTORY)
 
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('status.txt')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPResso_status.txt')))
 
         info('Checking dependencies...')
 

--- a/CRISPResso2/CRISPRessoWGSCORE.py
+++ b/CRISPResso2/CRISPRessoWGSCORE.py
@@ -334,7 +334,7 @@ def main():
         except:
             warn('Folder %s already exists.' % OUTPUT_DIRECTORY)
 
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPResso_status.txt')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPRessoWGS_status.txt')))
 
         info('Checking dependencies...')
 

--- a/CRISPResso2/CRISPRessoWGSCORE.py
+++ b/CRISPResso2/CRISPRessoWGSCORE.py
@@ -23,14 +23,11 @@ from CRISPResso2 import CRISPRessoPlot
 
 
 import logging
-logging.basicConfig(
-                     format='%(levelname)-5s @ %(asctime)s:\n\t %(message)s \n',
-                     datefmt='%a, %d %b %Y %H:%M:%S',
-                     stream=sys.stderr,
-                     filemode="w"
-                     )
+
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(CRISPRessoShared.LogStreamHandler())
+
 error   = logger.critical
 warn    = logger.warning
 debug   = logger.debug


### PR DESCRIPTION
This PR implements the following:

- Writing a `CRISPResso*_status.txt` file to the results directory that displays the latest log output as well as the percentage complete.
- Add the `--verbosity` parameter to specify the level that should be output. Note that when the `--debug` parameter is present, then by default the verbosity will be set to the most verbose.
- Changes how `run_crispresso_cmds` executes multiple concurrent CRISPResso runs so that the progress can be displayed as runs finish. When interrupting the multiple processes (with `Ctrl-C`) the `KeyboardInterrupt` traceback is shown in the CLI, but on my system it successfully closes each child process.