### PR TITLE
Allow for amplicon and guide seqs to be some variant of NA in batch

### DIFF
--- a/CRISPResso2/CRISPRessoBatchCORE.py
+++ b/CRISPResso2/CRISPRessoBatchCORE.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from concurrent.futures import ProcessPoolExecutor, wait
 from functools import partial
 import sys
+import re
 import traceback
 from datetime import datetime
 from CRISPResso2 import CRISPRessoShared
@@ -236,7 +237,7 @@ def main():
 
                 # iterate through guides
                 curr_guide_seq_string = row.guide_seq
-                if curr_guide_seq_string is not None and curr_guide_seq_string != "":
+                if curr_guide_seq_string is not None and re.match(r'(?i)^$|^nan?$', str(curr_guide_seq_string)) is None:
                     guides = str(curr_guide_seq_string).strip().upper().split(',')
                     for curr_guide_seq in guides:
                         wrong_nt = CRISPRessoShared.find_wrong_nt(curr_guide_seq)
@@ -271,8 +272,11 @@ def main():
 
             crispresso_cmd = args.crispresso_command + ' -o "%s" --name %s' % (OUTPUT_DIRECTORY, batch_name)
             crispresso_cmd = CRISPRessoShared.propagate_crispresso_options(crispresso_cmd, crispresso_options_for_batch, batch_params, idx)
-            if row.amplicon_seq == "":
+            if re.match(r'(?i)^$|^nan?$', str(row.amplicon_seq)) is not None:
                 crispresso_cmd += ' --auto '
+                crispresso_cmd = re.sub(r'--amplicon_seq\s+[^ ]+\s*', '', crispresso_cmd)
+            if re.match(r'(?i)^$|^nan?$', str(row.guide_seq)) is not None:
+                crispresso_cmd = re.sub(r'--guide_seq\s+[^ ]+\s*', '', crispresso_cmd)
             crispresso_cmds.append(crispresso_cmd)
 
         crispresso2_info['results']['batch_names_arr'] = batch_names_arr


### PR DESCRIPTION
This was discovered when attempting to infer amplicon sequences in batch mode on the web interface, NAs were supplied for the amplicon sequences to the sub CRISPResso commands.