### PR TITLE
Add top ticks to plots

### DIFF
--- a/CRISPResso2/CRISPRessoPlot.py
+++ b/CRISPResso2/CRISPRessoPlot.py
@@ -975,7 +975,8 @@ def plot_quantification_window_locations(
     )
     y_label_values = np.arange(0, 1, 1.0 / 6.0)
     if y_max > 0:
-        y_label_values = np.arange(0, y_max, y_max / 6.0).astype(int)
+        y_label_values = np.linspace(0, y_max, 6).astype(int)
+        y_label_values[-1] = y_max
     ax.set_yticks(y_label_values)
     ax.set_yticklabels(
         [

--- a/CRISPResso2/CRISPRessoPlot.py
+++ b/CRISPResso2/CRISPRessoPlot.py
@@ -795,7 +795,12 @@ def plot_modification_frequency(
     )
     y_label_values = np.arange(0, 1, 1.0 / 6.0)
     if y_max > 0:
-        y_label_values = np.arange(0, y_max, y_max / 6.0)
+        # Create 6 evenly spaced ticks from 0 to y_max (inclusive)
+        num_ticks = 6
+        y_label_values = np.linspace(0, y_max, num_ticks)
+        # Ensure the maximum value is included
+        if y_label_values[-1] < y_max:
+            y_label_values[-1] = y_max
     ax.set_xticks(np.arange(
         0,
         ref_len,

--- a/CRISPResso2/CRISPRessoPlot.py
+++ b/CRISPResso2/CRISPRessoPlot.py
@@ -350,6 +350,10 @@ def plot_indel_size_distribution(
     y_label_values = np.round(
         np.linspace(0, min(100, max(ax.get_yticks())), 6),
     )
+    # Ensure the maximum value is included
+    max_y = min(100, max(ax.get_yticks()))
+    if y_label_values[-1] < max_y:
+        y_label_values[-1] = max_y
     ax.set_yticks(y_label_values)
     ax.set_yticklabels([
         '%.1f%% (%.0f)' % (pct, pct / 100 * n_this_category)
@@ -430,6 +434,10 @@ def plot_frequency_deletions_insertions(
     y_label_values= np.round(
         np.linspace(0, min(counts_total, max(ax.get_yticks())), 6),
     )
+    # Ensure the maximum value is included
+    max_y = min(counts_total, max(ax.get_yticks()))
+    if y_label_values[-1] < max_y:
+        y_label_values[-1] = max_y
     ax.set_yticks(y_label_values)
     ax.set_yticklabels(
         [
@@ -633,7 +641,12 @@ def plot_amplicon_modifications(
     )
     y_label_values = np.arange(0, 1, 1.0 / 6.0)
     if y_max > 0:
-        y_label_values = np.arange(0, y_max, y_max / 6.0)
+        # Create 6 evenly spaced ticks from 0 to y_max (inclusive)
+        num_ticks = 6
+        y_label_values = np.linspace(0, y_max, num_ticks)
+        # Ensure the maximum value is included
+        if y_label_values[-1] < y_max:
+            y_label_values[-1] = y_max
     if num_refs == 1:
         ax.set_ylabel('Sequences: % Total ( no. )')
         ax.set_yticks(y_label_values)
@@ -1248,7 +1261,12 @@ def plot_global_modifications_reference(
     )
     y_label_values = np.arange(0, 1, 1.0 / 6.0)
     if y_max > 0:
-        y_label_values = np.arange(0, y_max, y_max / 6.0).astype(int)
+        # Create 6 evenly spaced ticks from 0 to y_max (inclusive)
+        num_ticks = 6
+        y_label_values = np.linspace(0, y_max, num_ticks).astype(int)
+        # Ensure the maximum value is included
+        if y_label_values[-1] < y_max:
+            y_label_values[-1] = int(y_max)
 
     ax.set_ylabel('Sequences: % Total ( no. )')
     ax.set_yticks(y_label_values)
@@ -1478,6 +1496,10 @@ def plot_frameshift_frequency(
     y_label_values = np.round(
         np.linspace(0, min(100, max(ax1.get_yticks())), 6),
     )
+    # Ensure the maximum value is included
+    max_y = min(100, max(ax1.get_yticks()))
+    if y_label_values[-1] < max_y:
+        y_label_values[-1] = max_y
     ax1.set_yticks(y_label_values)
     ax1.set_yticklabels(
         [
@@ -1517,6 +1539,10 @@ def plot_frameshift_frequency(
     y_label_values = np.round(
         np.linspace(0, min(100, max(ax2.get_yticks())), 6),
     )
+    # Ensure the maximum value is included
+    max_y = min(100, max(ax2.get_yticks()))
+    if y_label_values[-1] < max_y:
+        y_label_values[-1] = max_y
     ax2.set_yticks(y_label_values)
     ax2.set_yticklabels(
         [
@@ -1653,6 +1679,10 @@ def plot_global_frameshift_in_frame_mutations(
     y_label_values = np.round(np.linspace(
         0, min(100, max(ax2.get_yticks())), 6,
     ))
+    # Ensure the maximum value is included
+    max_y = min(100, max(ax2.get_yticks()))
+    if y_label_values[-1] < max_y:
+        y_label_values[-1] = max_y
     ax2.set_yticks(y_label_values)
     ax2.set_yticklabels(
         [
@@ -2257,6 +2287,10 @@ def plot_subs_across_ref(ref_len, ref_seq, ref_name, ref_count, all_substitution
     lgd = ax.legend(handles=legend_patches, labels=legend_labels, loc='upper center', bbox_to_anchor=(0.3, -0.15), ncol=2, fancybox=True, shadow=True)
 
     y_label_values= np.round(np.linspace(0, max(y_max, min(max(tots), max(ax.get_yticks()))), 6))# np.arange(0,y_max,y_max/6.0)
+    # Ensure the maximum value is included
+    max_y = max(y_max, min(max(tots), max(ax.get_yticks())))
+    if y_label_values[-1] < max_y:
+        y_label_values[-1] = max_y
     ax.set_yticks(y_label_values)
     ax.set_yticklabels(
         [

--- a/CRISPResso2/CRISPRessoPlot.py
+++ b/CRISPResso2/CRISPRessoPlot.py
@@ -1639,6 +1639,10 @@ def plot_global_frameshift_in_frame_mutations(
     y_label_values = np.round(np.linspace(
         0, min(100, max(ax1.get_yticks())), 6),
     )
+    # Ensure the maximum value is included
+    max_y = min(100, max(ax1.get_yticks()))
+    if y_label_values[-1] < max_y:
+        y_label_values[-1] = max_y
     ax1.set_yticks(y_label_values)
     ax1.set_yticklabels(
         [

--- a/CRISPResso2/CRISPRessoPlot.py
+++ b/CRISPResso2/CRISPRessoPlot.py
@@ -795,12 +795,9 @@ def plot_modification_frequency(
     )
     y_label_values = np.arange(0, 1, 1.0 / 6.0)
     if y_max > 0:
-        # Create 6 evenly spaced ticks from 0 to y_max (inclusive)
         num_ticks = 6
         y_label_values = np.linspace(0, y_max, num_ticks)
-        # Ensure the maximum value is included
-        if y_label_values[-1] < y_max:
-            y_label_values[-1] = y_max
+        y_label_values[-1] = y_max
     ax.set_xticks(np.arange(
         0,
         ref_len,

--- a/CRISPResso2/CRISPRessoPlot.py
+++ b/CRISPResso2/CRISPRessoPlot.py
@@ -72,6 +72,7 @@ def get_nuc_color(nuc, alpha):
 
         return (charSum, (1-charSum), (2*charSum*(1-charSum)))
 
+
 def get_color_lookup(nucs, alpha, custom_colors=None):
     if custom_colors is None:
         colorLookup = {}
@@ -94,6 +95,18 @@ def hex_to_rgb(value):
     value = value.lstrip('#')
     lv = len(value)
     return tuple(int(value[i:i + lv // 3], 16) for i in range(0, lv, lv // 3))
+
+
+def get_y_label_values(y_max, round=False, num_ticks=6):
+    """Get y label values that are evenly spaced."""
+    y_label_values = np.arange(0, 1, 1.0 / 6.0)
+    if y_max > 0:
+        y_label_values = np.linspace(0, y_max, num_ticks).astype(int)
+        y_label_values[-1] = int(y_max)
+        if round:
+            y_label_values = np.round(y_label_values)
+    return y_label_values
+
 
 def plot_nucleotide_quilt(nuc_pct_df,mod_pct_df,fig_filename_root, custom_colors, save_also_png=False,sgRNA_intervals=None,min_text_pct=0.5,max_text_pct=0.95,quantification_window_idxs=None,sgRNA_names=None,sgRNA_mismatches=None,shade_unchanged=True,group_column='Batch', **kwargs):
     """
@@ -347,13 +360,8 @@ def plot_indel_size_distribution(
     ax.set_xlim([xmin, xmax])
     ax.set_title(title)
     ax.set_ylabel('Sequences % (no.)')
-    y_label_values = np.round(
-        np.linspace(0, min(100, max(ax.get_yticks())), 6),
-    )
-    # Ensure the maximum value is included
     max_y = min(100, max(ax.get_yticks()))
-    if y_label_values[-1] < max_y:
-        y_label_values[-1] = max_y
+    y_label_values = get_y_label_values(max_y, round=True)
     ax.set_yticks(y_label_values)
     ax.set_yticklabels([
         '%.1f%% (%.0f)' % (pct, pct / 100 * n_this_category)
@@ -431,13 +439,8 @@ def plot_frequency_deletions_insertions(
         lgd.legend_handles[1].set_height(6)
 
     ax.set_xlim([-1, xmax_ins])
-    y_label_values= np.round(
-        np.linspace(0, min(counts_total, max(ax.get_yticks())), 6),
-    )
-    # Ensure the maximum value is included
     max_y = min(counts_total, max(ax.get_yticks()))
-    if y_label_values[-1] < max_y:
-        y_label_values[-1] = max_y
+    y_label_values = get_y_label_values(max_y, round=True)
     ax.set_yticks(y_label_values)
     ax.set_yticklabels(
         [
@@ -474,9 +477,8 @@ def plot_frequency_deletions_insertions(
         lgd.legend_handles[1].set_height(6)
 
     ax.set_xlim([-1 * xmax_del, 1])
-    y_label_values = np.round(
-        np.linspace(0, min(counts_total, max(ax.get_yticks())), 6),
-    )
+    y_max = min(counts_total, max(ax.get_yticks()))
+    y_label_values = get_y_label_values(y_max, round=True)
     ax.set_yticks(y_label_values)
     ax.set_yticklabels(
         [
@@ -513,9 +515,8 @@ def plot_frequency_deletions_insertions(
         lgd.legend_handles[1].set_height(6)
 
     ax.set_xlim([-1, xmax_mut])
-    y_label_values= np.round(
-        np.linspace(0, min(counts_total, max(ax.get_yticks())), 6),
-    )
+    y_max = min(counts_total, max(ax.get_yticks()))
+    y_label_values = get_y_label_values(y_max, round=True)
     ax.set_yticks(y_label_values)
     ax.set_yticklabels(
         [
@@ -639,14 +640,7 @@ def plot_amplicon_modifications(
         fancybox=True,
         shadow=True,
     )
-    y_label_values = np.arange(0, 1, 1.0 / 6.0)
-    if y_max > 0:
-        # Create 6 evenly spaced ticks from 0 to y_max (inclusive)
-        num_ticks = 6
-        y_label_values = np.linspace(0, y_max, num_ticks)
-        # Ensure the maximum value is included
-        if y_label_values[-1] < y_max:
-            y_label_values[-1] = y_max
+    y_label_values = get_y_label_values(y_max, round=True)
     if num_refs == 1:
         ax.set_ylabel('Sequences: % Total ( no. )')
         ax.set_yticks(y_label_values)
@@ -806,11 +800,7 @@ def plot_modification_frequency(
         fancybox=True,
         shadow=True,
     )
-    y_label_values = np.arange(0, 1, 1.0 / 6.0)
-    if y_max > 0:
-        num_ticks = 6
-        y_label_values = np.linspace(0, y_max, num_ticks)
-        y_label_values[-1] = y_max
+    y_label_values = get_y_label_values(y_max)
     ax.set_xticks(np.arange(
         0,
         ref_len,
@@ -973,10 +963,7 @@ def plot_quantification_window_locations(
         fancybox=True,
         shadow=True,
     )
-    y_label_values = np.arange(0, 1, 1.0 / 6.0)
-    if y_max > 0:
-        y_label_values = np.linspace(0, y_max, 6).astype(int)
-        y_label_values[-1] = y_max
+    y_label_values = get_y_label_values(y_max)
     ax.set_yticks(y_label_values)
     ax.set_yticklabels(
         [
@@ -1260,15 +1247,7 @@ def plot_global_modifications_reference(
         fancybox=True,
         shadow=True,
     )
-    y_label_values = np.arange(0, 1, 1.0 / 6.0)
-    if y_max > 0:
-        # Create 6 evenly spaced ticks from 0 to y_max (inclusive)
-        num_ticks = 6
-        y_label_values = np.linspace(0, y_max, num_ticks).astype(int)
-        # Ensure the maximum value is included
-        if y_label_values[-1] < y_max:
-            y_label_values[-1] = int(y_max)
-
+    y_label_values = get_y_label_values(y_max)
     ax.set_ylabel('Sequences: % Total ( no. )')
     ax.set_yticks(y_label_values)
     ax.set_yticklabels(
@@ -1494,13 +1473,7 @@ def plot_frameshift_frequency(
     ax1.tick_params(axis='both', which='major', labelsize=24)
     ax1.tick_params(axis='both', which='minor', labelsize=24)
     ax1.set_ylabel('Sequences % (no.)')
-    y_label_values = np.round(
-        np.linspace(0, min(100, max(ax1.get_yticks())), 6),
-    )
-    # Ensure the maximum value is included
-    max_y = min(100, max(ax1.get_yticks()))
-    if y_label_values[-1] < max_y:
-        y_label_values[-1] = max_y
+    y_label_values = get_y_label_values(max_y, round=True)
     ax1.set_yticks(y_label_values)
     ax1.set_yticklabels(
         [
@@ -1537,13 +1510,8 @@ def plot_frameshift_frequency(
     )
     ax2.set_title(plot_titles['if'])
     ax2.set_ylabel('Sequences % (no.)')
-    y_label_values = np.round(
-        np.linspace(0, min(100, max(ax2.get_yticks())), 6),
-    )
-    # Ensure the maximum value is included
     max_y = min(100, max(ax2.get_yticks()))
-    if y_label_values[-1] < max_y:
-        y_label_values[-1] = max_y
+    y_label_values = get_y_label_values(max_y, round=True)
     ax2.set_yticks(y_label_values)
     ax2.set_yticklabels(
         [
@@ -1637,13 +1605,8 @@ def plot_global_frameshift_in_frame_mutations(
     ax1.tick_params(axis='both', which='minor', labelsize=24)
     ax1.tick_params(left=True, bottom=True)
     ax1.set_ylabel('Sequences % (no.)')
-    y_label_values = np.round(np.linspace(
-        0, min(100, max(ax1.get_yticks())), 6),
-    )
-    # Ensure the maximum value is included
-    max_y = min(100, max(ax1.get_yticks()))
-    if y_label_values[-1] < max_y:
-        y_label_values[-1] = max_y
+    y_max = min(100, max(ax1.get_yticks()))
+    y_label_values = get_y_label_values(y_max, round=True)
     ax1.set_yticks(y_label_values)
     ax1.set_yticklabels(
         [
@@ -1681,13 +1644,8 @@ def plot_global_frameshift_in_frame_mutations(
     )
     ax2.set_title('Global In-frame profile')
     ax2.set_ylabel('Sequences % (no.)')
-    y_label_values = np.round(np.linspace(
-        0, min(100, max(ax2.get_yticks())), 6,
-    ))
-    # Ensure the maximum value is included
-    max_y = min(100, max(ax2.get_yticks()))
-    if y_label_values[-1] < max_y:
-        y_label_values[-1] = max_y
+    y_max = min(100, max(ax2.get_yticks()))
+    y_label_values = get_y_label_values(y_max, round=True)
     ax2.set_yticks(y_label_values)
     ax2.set_yticklabels(
         [
@@ -2291,11 +2249,8 @@ def plot_subs_across_ref(ref_len, ref_seq, ref_name, ref_count, all_substitution
 #    lgd=ax.legend(legend_patches,legend_labels,ncol=1)
     lgd = ax.legend(handles=legend_patches, labels=legend_labels, loc='upper center', bbox_to_anchor=(0.3, -0.15), ncol=2, fancybox=True, shadow=True)
 
-    y_label_values= np.round(np.linspace(0, max(y_max, min(max(tots), max(ax.get_yticks()))), 6))# np.arange(0,y_max,y_max/6.0)
-    # Ensure the maximum value is included
     max_y = max(y_max, min(max(tots), max(ax.get_yticks())))
-    if y_label_values[-1] < max_y:
-        y_label_values[-1] = max_y
+    y_label_values = get_y_label_values(max_y, round=True)
     ax.set_yticks(y_label_values)
     ax.set_yticklabels(
         [
@@ -3616,7 +3571,8 @@ def plot_read_barplot(N_READS_INPUT, N_READS_AFTER_PREPROCESSING, N_TOTAL,
     ax.set_xticks(np.arange(len(sizes)))
     ax.set_xticklabels(labels)
     ax.set_ylabel('Sequences % (no.)')
-    y_label_values = np.round(np.linspace(0, max(N_READS_INPUT, max(ax.get_yticks())), 6))
+    y_max = max(N_READS_INPUT, max(ax.get_yticks()))
+    y_label_values = get_y_label_values(y_max, round=True)
 
     ax.set_yticks(y_label_values)
     ax.set_yticklabels(['%.1f%% (%.0f)' % (100*cnt/N_READS_INPUT, cnt) for cnt in y_label_values])
@@ -3711,7 +3667,8 @@ def plot_class_piechart_and_barplot(class_counts_order, class_counts, ref_names,
     ax.set_xticklabels(labels)
     ax.set_xticklabels([X.replace("&", " & ").replace("_UNMODIFIED", " UNMODIFIED").replace("_MODIFIED", " MODIFIED") for X in labels])
     ax.set_ylabel('Sequences % (no.)')
-    y_label_values = np.round(np.linspace(0, min(100, max(ax.get_yticks())), 6))
+    y_max = min(100, max(ax.get_yticks()))
+    y_label_values = get_y_label_values(y_max, round=True)
     ax.set_yticks(y_label_values)
     ax.set_yticklabels(['%.1f%% (%.0f)' % (pct, pct/100*N_TOTAL) for pct in y_label_values])
     #if too many barplots, flip the labels


### PR DESCRIPTION
This PR adds tick marks that are above the maximum value of the data being plotted, such that it is easier to identify what the maximum value is. One downside of this approach is that the ticks are not necessarily evenly spaced anymore, and the maximum value isn't reflected (usually the maximum value of the plot is `1.1 * max_value`).

<img width="1449" alt="Screenshot 2025-04-03 at 4 16 53 PM" src="https://github.com/user-attachments/assets/d3a8ee07-937b-43bd-9b4f-9edfa836552e" />
