### PR TITLE
Add GitHub Action to check CHANGELOG.md updates in PRs

### DIFF
--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -1,0 +1,21 @@
+name: Changelog Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  changelog-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Check if CHANGELOG.md was updated
+      run: |
+        if git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD | grep -q '^CHANGELOG.md$'; then
+          echo "CHANGELOG.md has been updated."
+        else
+          echo "::warning::CHANGELOG.md has not been updated in this PR. Please consider adding a changelog entry."
+        fi


### PR DESCRIPTION
Adds a new workflow that runs on pull requests and emits a warning
annotation if CHANGELOG.md was not modified. The check is non-blocking
so it won't prevent merging, but will surface a visible reminder.

https://claude.ai/code/session_013KNzVbh3QVeCXRSATDywSg