### PR TITLE
Plot fixes

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -86,7 +86,6 @@ jobs:
         with:
           repository: edilytics/CRISPResso2_tests
           # ref: '<BRANCH-NAME>' # update to specific branch
-          ref: cole/plot-plugin-fixes
           path: CRISPResso2_tests
 
       - name: Checkout CRISPRessoPro

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -86,6 +86,7 @@ jobs:
         with:
           repository: edilytics/CRISPResso2_tests
           # ref: '<BRANCH-NAME>' # update to specific branch
+          ref: cole/plot-plugin-fixes
           path: CRISPResso2_tests
 
       - name: Checkout CRISPRessoPro

--- a/CRISPResso2/CRISPRessoReports/CRISPRessoReport.py
+++ b/CRISPResso2/CRISPRessoReports/CRISPRessoReport.py
@@ -151,7 +151,7 @@ def assemble_figs(run_data, crispresso_folder):
                                   'Figure ' + fig_name,
                                   run_data['results']['refs'][amplicon_name][fig_name + '_caption'],
                                   run_data['results']['refs'][amplicon_name][fig_name + '_data'],
-                                  global_fig_names, amplicon_figures, crispresso_folder, d3_nuc_quilt_names)
+                                  amplicon_figures['names'], amplicon_figures, crispresso_folder, d3_nuc_quilt_names)
 
         this_sgRNA_based_fig_names = {}
         for fig in ['2b', '9', '9a', '10d', '10e', '10f', '10g', '11b']:

--- a/CRISPResso2/CRISPRessoReports/templates/report.html
+++ b/CRISPResso2/CRISPRessoReports/templates/report.html
@@ -620,7 +620,6 @@
 
 {% block foot %}
 <script>
-{% if not C2PRO_INSTALLED or use_matplot_lib %}
 function updateZoom(e) {
   /*prevent any other actions that may occur when moving over the image:*/
 //  e.preventDefault();
@@ -716,7 +715,6 @@ try {
 
 		{% endif %}
 	{% endfor %}
-  {% endif %}
 </script>
 
 


### PR DESCRIPTION
This PR fixes a bug where the hovering breaks for plot 2a when CRISPRessoPro is installed, and corrects the `amplicon_figures` in the report generation.