### PR TITLE
Tolerate missing web legal partials in layout

### DIFF
--- a/CRISPResso2/CRISPRessoReports/templates/layout.html
+++ b/CRISPResso2/CRISPRessoReports/templates/layout.html
@@ -216,9 +216,11 @@
     </div>
     {% endif %}
     </div>
-    {%- if is_web %}{% include 'shared/partials/legal_footer.html' %}{% endif %}
-    {%- if is_web %}{% include 'shared/partials/cookie_banner.html' %}{% endif %}
-    {%- if is_web %}{% include 'shared/partials/eula_gate.html' %}{% endif %}
+    {# 'ignore missing': the web app supplies these, so a C2Web version that predates
+       them must still render rather than 500 on a template it never shipped #}
+    {%- if is_web %}{% include 'shared/partials/legal_footer.html' ignore missing %}{% endif %}
+    {%- if is_web %}{% include 'shared/partials/cookie_banner.html' ignore missing %}{% endif %}
+    {%- if is_web %}{% include 'shared/partials/eula_gate.html' ignore missing %}{% endif %}
     {% block foot %}{% endblock %}
   </body>
 

--- a/CRISPResso2/CRISPRessoReports/templates/layout.html
+++ b/CRISPResso2/CRISPRessoReports/templates/layout.html
@@ -216,8 +216,10 @@
     </div>
     {% endif %}
     </div>
-    {# 'ignore missing': the web app supplies these, so a C2Web version that predates
-       them must still render rather than 500 on a template it never shipped #}
+    {#- 'ignore missing': the web app supplies these, so a C2Web version that predates
+        them must still render rather than 500 on a template it never shipped.
+        Keep this comment whitespace-stripping: a non-stripping comment adds bytes to
+        every generated report and fails the CRISPResso2_tests HTML diffs. -#}
     {%- if is_web %}{% include 'shared/partials/legal_footer.html' ignore missing %}{% endif %}
     {%- if is_web %}{% include 'shared/partials/cookie_banner.html' ignore missing %}{% endif %}
     {%- if is_web %}{% include 'shared/partials/eula_gate.html' ignore missing %}{% endif %}


### PR DESCRIPTION
layout.html includes shared/partials/{legal_footer,cookie_banner,eula_gate}.html under `is_web`, but those templates are supplied by C2Web and do not exist in this repo. Until the C2Web side merges, any web deployment on this branch raises TemplateNotFound on every full page render.

Add `ignore missing` so the include is a no-op when the web app has not shipped the partial, decoupling the two repos' merge order.