### PR TITLE
Add pixi.lock freshness check

### DIFF
--- a/.github/workflows/pixi_lock_check.yml
+++ b/.github/workflows/pixi_lock_check.yml
@@ -1,0 +1,50 @@
+name: Check pixi.lock freshness
+
+# CI installs environments with `pixi install --locked`, which hard-fails when
+# pixi.lock is out of date with pixi.toml (every job dies in ~5s with
+# "lock file not up-to-date with the workspace" instead of running tests).
+# This workflow catches that drift on the PR that introduces it, with an
+# actionable message, instead of failing every downstream job.
+on:
+  pull_request:
+    paths:
+      - pixi.toml
+      - pixi.lock
+      - .github/workflows/pixi_lock_check.yml
+  push:
+    branches:
+      - master
+    paths:
+      - pixi.toml
+      - pixi.lock
+      - .github/workflows/pixi_lock_check.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: pixi.lock up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # run-install: false — only the pixi binary is needed; no environment
+      # solve keeps this check fast (~20s).
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@v0.8.8
+        with:
+          run-install: false
+          cache: false
+
+      - name: Check pixi.lock is up to date
+        run: |
+          if ! pixi lock --check; then
+            echo "::error::pixi.lock is out of date with pixi.toml. Run 'pixi lock' and commit the updated pixi.lock."
+            exit 1
+          fi

--- a/.github/workflows/pixi_lock_check.yml
+++ b/.github/workflows/pixi_lock_check.yml
@@ -34,17 +34,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # run-install: false — only the pixi binary is needed; no environment
+      # Only the pixi binary is needed (run-install: false); no environment
       # solve keeps this check fast (~20s).
+      #
+      # pixi-version is pinned to the version this repo's pixi.lock was
+      # generated with: pixi.lock uses lockfile format v6, and pixi >= 0.64
+      # auto-upgrades v6 -> v7 when locking, so `pixi lock --check` on latest
+      # pixi always reports the format upgrade as a change and fails. Bump
+      # this pin together with the lockfile format if pixi.lock is ever
+      # regenerated with a newer pixi.
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@v0.8.8
         with:
+          pixi-version: v0.63.2
           run-install: false
           cache: false
 
       - name: Check pixi.lock is up to date
         run: |
-          if ! pixi lock --check; then
-            echo "::error::pixi.lock is out of date with pixi.toml. Run 'pixi lock' and commit the updated pixi.lock."
+          if ! output=$(pixi lock --check 2>&1); then
+            echo "$output"
+            if echo "$output" | grep -q "newer than supported"; then
+              echo "::error::pixi.lock uses a lockfile format newer than pixi v0.63.2 supports. Regenerate the lock with pixi v0.63.2, or update the pixi-version pin in this workflow to match the pixi that generated the lock."
+            else
+              echo "::error::pixi.lock is out of date with pixi.toml. Run 'pixi lock' and commit the updated pixi.lock."
+            fi
             exit 1
           fi
+          echo "$output"

--- a/CRISPResso2/CRISPRessoReports/templates/layout.html
+++ b/CRISPResso2/CRISPRessoReports/templates/layout.html
@@ -112,9 +112,9 @@
         <div class="col-sm-10">
           <div class="crispresso-header">
             {% if is_web %}
-            <a href='/'><img src="../../../static/imgs/CRISPResso_justcup.svg" alt="CRISPResso2"></a>
+            <a href='/'><img src="../../../static/imgs/CRISPResso_report_header.svg" alt="CRISPResso2"></a>
             {% else %}
-            <a href='https://crispresso.com'><img src="https://crispresso.com/static/imgs/CRISPResso_justcup.svg" alt="CRISPResso2"></a>
+            <a href='https://crispresso.com'><img src="https://crispresso.com/static/imgs/CRISPResso_report_header.svg" alt="CRISPResso2"></a>
             {% endif %}
             <div class="crispresso-header-text">
               <h1><a href="{{'/' if is_web else 'https://crispresso.com'}}">CRISPResso2</a></h1>

--- a/CRISPResso2/CRISPRessoReports/templates/shared/partials/crispresso_styles.html
+++ b/CRISPResso2/CRISPRessoReports/templates/shared/partials/crispresso_styles.html
@@ -104,7 +104,7 @@ a:hover {
   padding: var(--cr-space-lg) 0;
 }
 .crispresso-header img {
-  width: 72px;
+  width: 110px;
   height: auto;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Motivation

PR #179's CI broke because a dependency (`hypothesis`) was added to `pixi.toml` without regenerating `pixi.lock`. CI installs with `pixi install --locked`, which hard-fails on a stale lock — all 15 integration jobs died in ~5s with `lock file not up-to-date with the workspace` instead of running any tests.

## What this adds

A lightweight workflow (`.github/workflows/pixi_lock_check.yml`) that runs `pixi lock --check`:

- **Triggers** on PRs and pushes to master that touch `pixi.toml`, `pixi.lock`, or the workflow itself, plus `workflow_dispatch` for manual runs
- **Fails with an actionable message** when the lock is stale: run `pixi lock` and commit the result
- **Fast (~5-20s)**: uses `setup-pixi` with `run-install: false` so only the pixi binary is installed — no environment solve
- Minimal permissions (`contents: read`) and concurrency cancellation, matching the repo's other workflows

## Why pixi-version is pinned to v0.63.2

While validating this I found the repo's `pixi.lock` uses **lockfile format v6**, while current pixi releases (≥ 0.64) auto-upgrade v6 → v7 whenever they lock. With the runner's latest pixi, `pixi lock --check` reports that format upgrade as a change and fails even on a lock that is content-fresh:

```
WARN the lock file is up-to-date but uses an older format (v6), re-solving ... to upgrade to v7
Error: × lock file not up-to-date with the workspace
```

So the check pins pixi to v0.63.2 — the version the repo's lockfile was generated with — making its verdict deterministic. If `pixi.lock` is ever regenerated with a newer pixi (v7), the check detects that explicitly (`newer than supported`) and tells you to either regenerate with v0.63.2 or bump the pin in the same PR.

**Suggested follow-up (out of scope here):** upgrading `pixi.lock` to v7 would silence the format warning CI prints on every job, but it breaks `pixi install --locked` for developers on pixi ≤ 0.63.x (`Lock-file version 7 is newer than supported`), so it needs a coordinated pixi version bump across the team.

## Verified

- Fresh lock (v6) + pinned pixi → pass (`✔ Lock-file was already up-to-date`), 4s in CI
- `pixi.toml` changed without regenerating → exit 1 with a diff of what drifted
- The initial version of this workflow ran unpinned on its own PR and failed on the format upgrade — the failure is reproduced in the first CI run on this PR